### PR TITLE
Implement basic "Trilha Estratégica"

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,6 @@
 
     <!-- Menu flutuante das configurações -->
     <div id="settingsMenu">
-      <button id="simuladoBtn" disabled>Simulado Personalizado</button>
-      <button id="erradasBtn"  disabled>Erradas da Semana</button>
       <button id="trilhaBtn">Trilha Estratégica</button>
       <button id="importBtn">Importar</button>
       <button id="exportBtn">Exportar</button>

--- a/index.html
+++ b/index.html
@@ -52,20 +52,20 @@
   <div id="header">
     <button id="backBtn">
       <i class="fas fa-arrow-left"></i>
-      <!-- Botão engrenagem -->
-      <button id="settingsBtn" aria-label="Configurações">
-        <i class="fas fa-cog"></i>
-      </button>
-
-      <!-- Menu flutuante das configurações -->
-      <div id="settingsMenu">
-        <button id="simuladoBtn" disabled>Simulado Personalizado</button>
-        <button id="erradasBtn"  disabled>Erradas da Semana</button>
-        <button id="trilhaBtn">Trilha Estratégica</button>
-        <button id="importBtn">Importar</button>
-        <button id="exportBtn">Exportar</button>
-      </div>
     </button>
+    <!-- Botão engrenagem -->
+    <button id="settingsBtn" aria-label="Configurações">
+      <i class="fas fa-cog"></i>
+    </button>
+
+    <!-- Menu flutuante das configurações -->
+    <div id="settingsMenu">
+      <button id="simuladoBtn" disabled>Simulado Personalizado</button>
+      <button id="erradasBtn"  disabled>Erradas da Semana</button>
+      <button id="trilhaBtn">Trilha Estratégica</button>
+      <button id="importBtn">Importar</button>
+      <button id="exportBtn">Exportar</button>
+    </div>
     <div class="header-top">
       <span id="headerTitle">Título Dinâmico</span>
     </div>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
       <div id="settingsMenu">
         <button id="simuladoBtn" disabled>Simulado Personalizado</button>
         <button id="erradasBtn"  disabled>Erradas da Semana</button>
+        <button id="trilhaBtn">Trilha Estratégica</button>
         <button id="importBtn">Importar</button>
         <button id="exportBtn">Exportar</button>
       </div>
@@ -138,6 +139,20 @@
       <div id="pomodoroControls" style="display:none;">
         <button id="pauseResumeBtn">Pausar</button>
         <button id="stopBtn">Sair</button>
+      </div>
+    </div>
+  </div>
+  <!-- Modal de seleção de assunto para a Trilha -->
+  <div id="subjectPickerModal">
+    <div class="modal-content">
+      <h3>Selecionar Assunto</h3>
+      <div class="picker-row">
+        <select id="pickerDisc"></select>
+        <select id="pickerSub"></select>
+      </div>
+      <div class="picker-actions">
+        <button id="pickerAdd">Adicionar</button>
+        <button id="pickerCancel">Cancelar</button>
       </div>
     </div>
   </div>

--- a/main.js
+++ b/main.js
@@ -496,7 +496,8 @@ function renderTrailDay(day,expand){
   const weekDay = day.toLocaleDateString('pt-BR',{weekday:'long'});
   const dateFmt = day.toLocaleDateString('pt-BR');
   btn.className='day-btn';
-  btn.textContent=`${weekDay} - ${dateFmt} - ${diffDays} dias`;
+  btn.innerHTML=`<span class="day-label">${weekDay} - ${dateFmt} - ${diffDays} dias</span>`+
+    `<i class="day-arrow fas fa-chevron-down"></i>`;
 
   const content=document.createElement('div');
   content.className='day-content';
@@ -555,6 +556,7 @@ function showTrail(expandDay){
   leaveHome();
   toggleSettingsVisibility(false);
   updateHeader(true,'Trilha Estratégica');
+  document.getElementById('headerStats').style.display='none';
   clear();
   window.scrollTo(0,0);
   const start=new Date();

--- a/main.js
+++ b/main.js
@@ -349,6 +349,7 @@ function showMenu () {
   currentDisc = currentSub = null;
   enterHome();            // aplica o visual preto + ajustes
   updateHeader(true);
+  document.getElementById('headerStats').style.visibility='visible';
   clear();                   // <- apaga o conteúdo de #app sem afetar xpModal
 
   /* 3 ▸ Introdução */
@@ -524,16 +525,27 @@ function renderTrailDay(day,expand){
     data[key].forEach((s,idx)=>{
       const item=document.createElement('div');
       item.className='trail-item';
-      const labelText=`${s.disc}: ${getFriendlyName(s.disc,s.sub)}`;
+
+      const label=`${s.disc}: ${getFriendlyName(s.disc,s.sub)}`;
       const qcount=countDailySolved(dayStr,s.disc,s.sub);
-      const link=document.createElement('button');
-      link.className='small-btn';
-      link.textContent=labelText+` (${qcount})`;
-      link.onclick=()=>{ trailReturn=dayStr; showQuestions(s.disc,s.sub); };
+
+      const subj=document.createElement('button');
+      subj.className=`trail-subject ${discClasses[s.disc]}`;
+      subj.textContent=label;
+      subj.onclick=()=>{ trailReturn=dayStr; showQuestions(s.disc,s.sub); };
+
+      const count=document.createElement('span');
+      count.className='trail-count';
+      count.textContent=qcount;
+
       const rm=document.createElement('button');
-      rm.textContent='x';
+      rm.className='trail-remove';
+      rm.textContent='×';
       rm.onclick=()=>{ data[key].splice(idx,1); saveTrail(dayStr,data); showTrail(dayStr); };
-      item.appendChild(link); item.appendChild(rm);
+
+      item.appendChild(subj);
+      item.appendChild(count);
+      item.appendChild(rm);
       sec.appendChild(item);
     });
     return sec;
@@ -556,7 +568,9 @@ function showTrail(expandDay){
   leaveHome();
   toggleSettingsVisibility(false);
   updateHeader(true,'Trilha Estratégica');
-  document.getElementById('headerStats').style.display='none';
+  const stats=document.getElementById('headerStats');
+  stats.style.display='block';
+  stats.style.visibility='hidden';
   clear();
   window.scrollTo(0,0);
   const start=new Date();
@@ -573,6 +587,7 @@ function showSubjects(disc) {
 
   // 1) Atualiza o cabeçalho normalmente
   updateHeader(true, disc);
+  document.getElementById('headerStats').style.visibility='visible';
 
   // 2) Anexa ao título da disciplina o toggle de ordenação
   headerTitle.style.cursor = 'pointer';
@@ -666,6 +681,7 @@ function showQuestions(disc, sub) {
   leaveHome();            // volta ao visual normal fora da Home
   toggleSettingsVisibility(false);  // esconde engrenagem
   updateHeader(true, `${disc}: ${getFriendlyName(disc, sub)}`);
+  document.getElementById('headerStats').style.visibility='visible';
   clear();
   window.scrollTo(0, 0);
 

--- a/main.js
+++ b/main.js
@@ -508,20 +508,19 @@ function renderTrailDay(day,expand){
   const makeSection=(label,key)=>{
     const sec=document.createElement('div');
     sec.className='trail-section';
-    const head=document.createElement('div');
-    head.className='trail-section-header';
-    head.innerHTML=`<span>${label}</span>`;
-    const add=document.createElement('button');
-    add.textContent='+';
-    add.onclick=()=>{
+    const wrap=document.createElement('div');
+    wrap.className='trail-section-header';
+    const btnAdd=document.createElement('button');
+    btnAdd.textContent=label;
+    btnAdd.onclick=()=>{
       openPicker(sel=>{
         data[key].push(sel);
         saveTrail(dayStr,data);
         showTrail(dayStr); // re-render
       });
     };
-    head.appendChild(add);
-    sec.appendChild(head);
+    wrap.appendChild(btnAdd);
+    sec.appendChild(wrap);
     data[key].forEach((s,idx)=>{
       const item=document.createElement('div');
       item.className='trail-item';

--- a/styles.css
+++ b/styles.css
@@ -605,16 +605,38 @@ button:hover { filter: brightness(1.2); }
   align-items: center;
   cursor: pointer;
 }
-
-.day-arrow {
-  transition: transform .2s;
-}
-
 .day-btn.open .day-arrow { transform: rotate(180deg); }
+  padding: 0;
 
-.day-content {
+/* Trail */
   width: 100%;
-  max-width: 820px;
+  text-align: center;
+  width: 100%;
+  text-align: center;
+
+/* Items */
+  gap: 6px;
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+/* Compact remove “x” */
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+/* Subject variants */
+
+/* Hide the old "+" add button (if still in DOM) */
+.trail-add { display: none !important; }
+
+/* General modal styles */
   background: var(--c-bg-panel);
   border: 1px solid var(--c-border-muted);
   border-top: none;

--- a/styles.css
+++ b/styles.css
@@ -632,16 +632,20 @@ button:hover { filter: brightness(1.2); }
 }
 .trail-section-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   margin-bottom: 6px;
   font-weight: bold;
 }
-.trail-section-header button { padding: 2px 6px; }
+.trail-section-header button {
+  padding: 1px 8px;
+  font-size: 14px;
+  margin-left: auto;
+}
 .trail-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   margin: 4px 0;
 }
 .trail-subject {
@@ -650,8 +654,9 @@ button:hover { filter: brightness(1.2); }
   color: #000;
   font-weight: 600;
   border-radius: 4px;
-  padding: 6px 10px;
+  padding: 8px 14px;
   cursor: pointer;
+  text-align: left;
 }
 .trail-count {
   background: #333;
@@ -664,8 +669,9 @@ button:hover { filter: brightness(1.2); }
   background: transparent;
   border: none;
   color: var(--c-text-muted);
-  font-size: 14px;
-  padding: 0 4px;
+  font-size: 12px;
+  padding: 0 2px;
+  margin-left: auto;
   cursor: pointer;
 }
 .trail-subject.biologia   { background: var(--c-bio); }

--- a/styles.css
+++ b/styles.css
@@ -594,32 +594,54 @@ button:hover { filter: brightness(1.2); }
 .day-btn {
   width: 100%;
   max-width: 820px;
-  margin-bottom: 6px;
+  margin-top: 8px;
+  padding: 10px;
+  background: var(--c-bg-panel);
+  color: var(--c-text-primary);
+  border: 1px solid var(--c-border-muted);
+  border-radius: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+.day-arrow {
+  transition: transform .2s;
+}
+.day-btn.open .day-arrow {
+  transform: rotate(180deg);
 }
 .day-content {
   width: 100%;
   max-width: 820px;
   background: var(--c-bg-panel);
-  padding: 8px;
+  border: 1px solid var(--c-border-muted);
+  border-top: none;
+  border-radius: 0 0 6px 6px;
+  padding: 10px;
   margin-bottom: 12px;
   display: none;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 .day-btn.open + .day-content { display: flex; }
 .trail-section {
-  border: 1px solid var(--c-border-muted);
+  background: #181818;
+  border-radius: 6px;
   padding: 6px;
 }
 .trail-section-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 4px;
+  align-items: center;
+  margin-bottom: 6px;
+  font-weight: bold;
 }
 .trail-section-header button { padding: 2px 6px; }
 .trail-item {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin: 2px 0;
 }
 #subjectPickerModal {

--- a/styles.css
+++ b/styles.css
@@ -640,10 +640,38 @@ button:hover { filter: brightness(1.2); }
 .trail-section-header button { padding: 2px 6px; }
 .trail-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin: 2px 0;
+  gap: 6px;
+  margin: 4px 0;
 }
+.trail-subject {
+  flex: 1;
+  border: none;
+  color: #000;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.trail-count {
+  background: #333;
+  color: var(--c-text-primary);
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 13px;
+}
+.trail-remove {
+  background: transparent;
+  border: none;
+  color: var(--c-text-muted);
+  font-size: 14px;
+  padding: 0 4px;
+  cursor: pointer;
+}
+.trail-subject.biologia   { background: var(--c-bio); }
+.trail-subject.quimica    { background: var(--c-qui); }
+.trail-subject.fisica     { background: var(--c-fis); }
+.trail-subject.matematica { background: var(--c-mat); }
 #subjectPickerModal {
   position: fixed;
   inset: 0;

--- a/styles.css
+++ b/styles.css
@@ -590,6 +590,56 @@ button:hover { filter: brightness(1.2); }
   opacity:.45;
   cursor:default;
 }
+/* === Trilha Estratégica === */
+.day-btn {
+  width: 100%;
+  max-width: 820px;
+  margin-bottom: 6px;
+}
+.day-content {
+  width: 100%;
+  max-width: 820px;
+  background: var(--c-bg-panel);
+  padding: 8px;
+  margin-bottom: 12px;
+  display: none;
+  flex-direction: column;
+  gap: 8px;
+}
+.day-btn.open + .day-content { display: flex; }
+.trail-section {
+  border: 1px solid var(--c-border-muted);
+  padding: 6px;
+}
+.trail-section-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+.trail-section-header button { padding: 2px 6px; }
+.trail-item {
+  display: flex;
+  justify-content: space-between;
+  margin: 2px 0;
+}
+#subjectPickerModal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+#subjectPickerModal .modal-content {
+  background: var(--c-bg-panel);
+  color: var(--c-text-primary);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+#subjectPickerModal select { margin: 0 4px; }
+#subjectPickerModal .picker-actions { margin-top: 10px; }
 /* ───────────── HOME LOOK ───────────── */
 body.home #header          { background: var(--c-bg-app); }   /* barra preta */
 

--- a/styles.css
+++ b/styles.css
@@ -590,7 +590,7 @@ button:hover { filter: brightness(1.2); }
   opacity:.45;
   cursor:default;
 }
-/* === Trilha Estratégica === */
+/* === Trilha Estratégica (v2) === */
 .day-btn {
   width: 100%;
   max-width: 820px;
@@ -605,12 +605,13 @@ button:hover { filter: brightness(1.2); }
   align-items: center;
   cursor: pointer;
 }
+
 .day-arrow {
   transition: transform .2s;
 }
-.day-btn.open .day-arrow {
-  transform: rotate(180deg);
-}
+
+.day-btn.open .day-arrow { transform: rotate(180deg); }
+
 .day-content {
   width: 100%;
   max-width: 820px;
@@ -618,38 +619,48 @@ button:hover { filter: brightness(1.2); }
   border: 1px solid var(--c-border-muted);
   border-top: none;
   border-radius: 0 0 6px 6px;
-  padding: 10px;
+  padding: 0;
   margin-bottom: 12px;
   display: none;
   flex-direction: column;
-  gap: 10px;
 }
+
 .day-btn.open + .day-content { display: flex; }
+
+/* Trail */
 .trail-section {
   background: #181818;
   border-radius: 6px;
   padding: 6px;
 }
+
 .trail-section-header {
+  width: 100%;
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  text-align: center;
   margin-bottom: 6px;
   font-weight: bold;
 }
+
 .trail-section-header button {
-  padding: 1px 8px;
+  width: 100%;
   font-size: 14px;
+  text-align: center;
   margin-left: auto;
 }
+
+/* Items */
 .trail-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   margin: 4px 0;
 }
+
 .trail-subject {
-  flex: 1;
+  flex: 1 1 auto;          /* fills all the space except count + x  */
   border: none;
   color: #000;
   font-weight: 600;
@@ -657,7 +668,11 @@ button:hover { filter: brightness(1.2); }
   padding: 8px 14px;
   cursor: pointer;
   text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
 .trail-count {
   background: #333;
   color: var(--c-text-primary);
@@ -665,19 +680,34 @@ button:hover { filter: brightness(1.2); }
   border-radius: 12px;
   font-size: 13px;
 }
+
+/* Compact remove “x” */
 .trail-remove {
+  flex: 0 0 24px;          /* exact tiny slot on the far right */
+  width: 24px;
+  height: 24px;
   background: transparent;
   border: none;
   color: var(--c-text-muted);
-  font-size: 12px;
-  padding: 0 2px;
-  margin-left: auto;
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;       /* pushes to the extreme right */
   cursor: pointer;
 }
+
+/* Subject variants */
 .trail-subject.biologia   { background: var(--c-bio); }
 .trail-subject.quimica    { background: var(--c-qui); }
 .trail-subject.fisica     { background: var(--c-fis); }
 .trail-subject.matematica { background: var(--c-mat); }
+
+/* Hide the old "+" add button (if still in DOM) */
+.trail-add { display: none !important; }
+
+/* General modal styles */
 #subjectPickerModal {
   position: fixed;
   inset: 0;
@@ -687,6 +717,7 @@ button:hover { filter: brightness(1.2); }
   justify-content: center;
   z-index: 2000;
 }
+
 #subjectPickerModal .modal-content {
   background: var(--c-bg-panel);
   color: var(--c-text-primary);
@@ -694,8 +725,10 @@ button:hover { filter: brightness(1.2); }
   border-radius: 8px;
   text-align: center;
 }
+
 #subjectPickerModal select { margin: 0 4px; }
 #subjectPickerModal .picker-actions { margin-top: 10px; }
+
 /* ───────────── HOME LOOK ───────────── */
 body.home #header          { background: var(--c-bg-app); }   /* barra preta */
 

--- a/styles.css
+++ b/styles.css
@@ -605,38 +605,16 @@ button:hover { filter: brightness(1.2); }
   align-items: center;
   cursor: pointer;
 }
+
+.day-arrow {
+  transition: transform .2s;
+}
+
 .day-btn.open .day-arrow { transform: rotate(180deg); }
-  padding: 0;
 
-/* Trail */
+.day-content {
   width: 100%;
-  text-align: center;
-  width: 100%;
-  text-align: center;
-
-/* Items */
-  gap: 6px;
-  flex: 1 1 auto;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-/* Compact remove “x” */
-  flex: 0 0 24px;
-  width: 24px;
-  height: 24px;
-  font-size: 14px;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-/* Subject variants */
-
-/* Hide the old "+" add button (if still in DOM) */
-.trail-add { display: none !important; }
-
-/* General modal styles */
+  max-width: 820px;
   background: var(--c-bg-panel);
   border: 1px solid var(--c-border-muted);
   border-top: none;


### PR DESCRIPTION
## Summary
- add **Trilha Estratégica** option in the settings menu
- provide subject picker modal and styling for the new feature
- implement trail pages with daily sections for new and review topics
- persist trail data and track solved questions per day
- make back button return to the trail when navigating from it

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847038671008321a8b36c160f7e140a