### PR TITLE
Fix KaTeX styles in text editor

### DIFF
--- a/Editor_de_Texto.html
+++ b/Editor_de_Texto.html
@@ -70,13 +70,22 @@ button:hover{background:var(--accent);}button:active{transform:scale(.96);}#mess
   white-space:pre-wrap;
 }
 
-/* aplica a MESMA fonte/tamanho a qualquer elemento dentro do editor */
+/* aplica fonte/tamanho padronizados, mas preserva estilos do KaTeX */
 #editor *,#editor *::before,#editor *::after{
-  font-family:inherit !important;
-  font-size:inherit  !important;
+  font-family:inherit;
+  font-size:inherit;
   white-space:pre-wrap !important;
   overflow-wrap:break-word !important;
   word-break:break-word   !important;
+}
+
+/* restaura estilos essenciais do KaTeX */
+#editor .katex, #editor .katex * {
+  font-family:revert !important;
+  font-size:revert !important;
+  white-space:normal !important;
+  overflow-wrap:normal !important;
+  word-break:normal !important;
 }
 
 #editor p{margin:2px 0;line-height:1.3;}


### PR DESCRIPTION
## Summary
- stop overriding KaTeX layout rules in the rich text editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68504fe700c08321b2243c3c181d5e21