### PR TITLE
Add exam menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
     <!-- Menu flutuante das configurações -->
     <div id="settingsMenu">
       <button id="trilhaBtn">Trilha Estratégica</button>
+      <button id="examsBtn">Provas e Simulados</button>
       <button id="importBtn">Importar</button>
       <button id="exportBtn">Exportar</button>
     </div>


### PR DESCRIPTION
## Summary
- add Provas e Simulados option
- build exam map and listing functions
- show questions by exam with colored topics
- handle navigation for new menu

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685e7ebe64e483219702231eae419305