### PR TITLE
Improve export function with timestamp and folder picker

### DIFF
--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -28,7 +28,7 @@ Essa estrutura torna o processo de revisão muito mais eficaz, permitindo que o 
 
 💾 Backup Inteligente
 Exporte e importe seus dados de progresso, comentários e marcações com facilidade. Ideal para trocar de dispositivo ou manter seus dados sempre seguros.
-* Os arquivos de backup agora são nomeados como `Newtonius_AAAA_MM_DD_HH_mm.json` e, quando o navegador permite, é possível escolher onde salvá-los.
+* Os arquivos de backup agora são nomeados como `Newtonius_AAAA_MM_DD_HH_mm.json`. Se o navegador não permitir a escolha da pasta, o download é feito normalmente.
 
 🛠️ Atualizações Futuras
 ...

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -28,6 +28,7 @@ Essa estrutura torna o processo de revisão muito mais eficaz, permitindo que o 
 
 💾 Backup Inteligente
 Exporte e importe seus dados de progresso, comentários e marcações com facilidade. Ideal para trocar de dispositivo ou manter seus dados sempre seguros.
+* Os arquivos de backup agora trazem a data e hora no nome e, quando o navegador permite, é possível escolher onde salvá-los.
 
 🛠️ Atualizações Futuras
 ...

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -28,7 +28,7 @@ Essa estrutura torna o processo de revisão muito mais eficaz, permitindo que o 
 
 💾 Backup Inteligente
 Exporte e importe seus dados de progresso, comentários e marcações com facilidade. Ideal para trocar de dispositivo ou manter seus dados sempre seguros.
-* Os arquivos de backup agora trazem a data e hora no nome e, quando o navegador permite, é possível escolher onde salvá-los.
+* Os arquivos de backup agora são nomeados como `Newtonius_AAAA_MM_DD_HH_mm.json` e, quando o navegador permite, é possível escolher onde salvá-los.
 
 🛠️ Atualizações Futuras
 ...

--- a/main.js
+++ b/main.js
@@ -231,14 +231,38 @@ function doExport() {
   const objOrdenado = Object.fromEntries(pares);
 
   /* 4 ▸ salva com indentação bonitinha */
-  const blob = new Blob(
-    [JSON.stringify(objOrdenado, null, 2)],        // <-- indent=2
-    { type: "application/json" }
-  );
+  const data = JSON.stringify(objOrdenado, null, 2);
+
+  /* 5 ▸ gera nome com data e hora */
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `backup_newtonius_${stamp}.json`;
+
+  /* 6 ▸ se disponível, usa File System Access para escolher pasta */
+  if (window.showSaveFilePicker) {
+    (async () => {
+      try {
+        const handle = await window.showSaveFilePicker({
+          suggestedName: filename,
+          types: [{
+            description: "JSON",
+            accept: { "application/json": [".json"] }
+          }]
+        });
+        const writable = await handle.createWritable();
+        await writable.write(data);
+        await writable.close();
+      } catch (err) {
+        console.error("Export falhou", err);
+      }
+    })();
+    return;
+  }
+
+  const blob = new Blob([data], { type: "application/json" });
 
   const a = document.createElement("a");
   a.href = URL.createObjectURL(blob);
-  a.download = "backup_newtonius.json";
+  a.download = filename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/main.js
+++ b/main.js
@@ -233,9 +233,25 @@ function doExport() {
   /* 4 ▸ salva com indentação bonitinha */
   const data = JSON.stringify(objOrdenado, null, 2);
 
-  /* 5 ▸ gera nome com data e hora */
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const filename = `backup_newtonius_${stamp}.json`;
+  /* 5 ▸ gera nome Newtonius_AAAA_MM_DD_HH_mm (hora de Brasília) */
+  const opts = {
+    timeZone: 'America/Sao_Paulo',
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  };
+  const parts = new Intl.DateTimeFormat('en-GB', opts)
+                    .formatToParts(new Date());
+  const dateMap = {};
+  for (const p of parts) {
+    if (p.type !== 'literal') dateMap[p.type] = p.value;
+  }
+  const stamp = `${dateMap.year}_${dateMap.month}_${dateMap.day}` +
+                `_${dateMap.hour}_${dateMap.minute}`;
+  const filename = `Newtonius_${stamp}.json`;
 
   /* 6 ▸ se disponível, usa File System Access para escolher pasta */
   if (window.showSaveFilePicker) {

--- a/main.js
+++ b/main.js
@@ -209,7 +209,7 @@ function buildExamMap(list){
   }
   return { map: exams, order };
 }
-function doExport() {
+async function doExport() {
   /* 1 ▸ lê tudo do localStorage e joga num array  [key,value] */
   const pares = [];
   for (let i = 0; i < localStorage.length; i++) {
@@ -253,36 +253,37 @@ function doExport() {
                 `_${dateMap.hour}_${dateMap.minute}`;
   const filename = `Newtonius_${stamp}.json`;
 
-  /* 6 ▸ se disponível, usa File System Access para escolher pasta */
+  /* 6 ▸ tenta usar File System Access. Se falhar, baixa direto */
+  let saved = false;
   if (window.showSaveFilePicker) {
-    (async () => {
-      try {
-        const handle = await window.showSaveFilePicker({
-          suggestedName: filename,
-          types: [{
-            description: "JSON",
-            accept: { "application/json": [".json"] }
-          }]
-        });
-        const writable = await handle.createWritable();
-        await writable.write(data);
-        await writable.close();
-      } catch (err) {
-        console.error("Export falhou", err);
-      }
-    })();
-    return;
+    try {
+      const handle = await window.showSaveFilePicker({
+        suggestedName: filename,
+        types: [{
+          description: "JSON",
+          accept: { "application/json": [".json"] }
+        }]
+      });
+      const writable = await handle.createWritable();
+      await writable.write(data);
+      await writable.close();
+      saved = true;
+    } catch (err) {
+      console.error("Export falhou", err);
+    }
   }
 
-  const blob = new Blob([data], { type: "application/json" });
+  if (!saved) {
+    const blob = new Blob([data], { type: "application/json" });
 
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(a.href);
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(a.href);
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add timestamp to exported backup file name
- allow choosing save folder when browser supports File System Access API
- document the new export behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f023f29408321ba070d4401d6643d