### PR TITLE
Improve mobile layout and PDF viewer

### DIFF
--- a/main.js
+++ b/main.js
@@ -1230,9 +1230,10 @@ async function openPdf(pdfName, pages, quality=2, zoom=1.75) {
     const page     = await pdf.getPage(num);
     const viewport = page.getViewport({ scale });
     const canvas   = Object.assign(document.createElement("canvas"), {
-      width: viewport.width, height: viewport.height,
+      width: viewport.width,
+      height: viewport.height,
       style: `width:${viewport.width/(quality*dpr)}px;
-              height:${viewport.height/(quality*dpr)}px;
+              height:auto;
               margin:16px 0;max-width:100%`
     });
     pdfContainer.appendChild(canvas);

--- a/styles.css
+++ b/styles.css
@@ -455,8 +455,8 @@ button:hover { filter: brightness(1.2); }
 
 /* cada exame injeta a cor da faixa */
 .exam-enem       { --stripe-color: var(--c-exam-enem); }
-.exam-sas        { --stripe-color: var(--c-exam-sas); }
-.exam-bernoulli  { --stripe-color: var(--c-exam-bernoulli); }
+.exam-sas        { --stripe-color: var(--c-exam-sas);    background: var(--c-exam-sas);    color: #fff; width: 260px; }
+.exam-bernoulli  { --stripe-color: var(--c-exam-bernoulli); background: var(--c-exam-bernoulli); color: #fff; width: 260px; }
 
 /* === Botão Pomodoro === */
 #pomodoroBtn {
@@ -920,7 +920,8 @@ body.home #headerStats      { display: none !important; }      /* esconde estat�
     text-align: center;
   }
   .intro-img { margin-right: 0; }
-  .comment-input {
+  .comment-input,
+  .comment-edit {
     flex: 1 1 100%;        /* ocupa 100 % da largura em telas menores */
     margin: 8px 0 0 0;
   }
@@ -954,9 +955,16 @@ body.home #headerStats      { display: none !important; }      /* esconde estat�
   }
 
   /* ---------- Campo de comentário -------- */
-  .comment-input{
+  .comment-input,
+  .comment-edit{
     flex: 1 1 100%;           /* ocupa 100 % da nova linha */
     width: 100%;              /* garante cobertura total   */
     margin: 8px 0 0 0;        /* mantém distanciamento */
+  }
+
+  /* Botões de simulados ocupam toda a largura */
+  .exam-sas,
+  .exam-bernoulli {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- adjust comment field layout for mobile and width
- colorize simulated exam buttons
- ensure simulated buttons use full width on mobile
- keep PDF proportions on mobile by using auto height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f1b250e0c8321b7de0e9cc114000d