### PR TITLE
Fix mobile question layout and pdf scaling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -348,10 +348,11 @@ button:hover { filter: brightness(1.2); }
   overflow-y: auto;
   z-index: 1000;
 }
-#pdfCanvas {
-  max-width: 100%;
-  max-height: 80%;
+#pdfViewerContainer canvas {
+  width: 100% !important;   /* ocupa toda a largura disponível */
+  height: auto !important;  /* preserva proporção original    */
   box-shadow: 0 0 10px rgba(0, 0, 0, .5);
+  margin: 16px 0;
 }
 #closePdfBtn {
   position: fixed;
@@ -938,6 +939,7 @@ body.home #headerStats      { display: none !important; }      /* esconde estat�
   .question-btn{
     flex: 1 1 auto;
     min-width: 0;             /* autoriza encolher abaixo do texto */
+    width: auto;              /* permite encolher em telas estreitas */
   }
 
   /* Botão "Gabarito" — largura fixa compacta */
@@ -954,9 +956,9 @@ body.home #headerStats      { display: none !important; }      /* esconde estat�
   }
 
   /* ---------- Campo de comentário -------- */
-  .comment-input{
-    flex: 1 1 100%;           /* ocupa 100 % da nova linha */
-    width: 100%;              /* garante cobertura total   */
-    margin: 8px 0 0 0;        /* mantém distanciamento */
+  .comment-edit{
+    flex: 1 1 100%;           /* ocupa 100% da nova linha */
+    width: 100%;              /* cobre toda a largura      */
+    margin: 8px 0 0 0;        /* mantém distanciamento     */
   }
 }


### PR DESCRIPTION
## Summary
- keep question button, gabarito and checkbox on the first line
- move comment field to its own line on mobile
- scale PDF canvases responsively

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f24ad621c832195e928e46d8099ce