### PR TITLE
Widen exam buttons

### DIFF
--- a/main.js
+++ b/main.js
@@ -823,7 +823,7 @@ function showExamList(){
   examOrder.forEach(ex=>{
     const btn=document.createElement('button');
     btn.textContent=ex;
-    btn.className='btn';
+    btn.className='btn exam-btn';
     const m=ex.match(/ENEM|SAS|BERNOULLI/i);
     if(m) btn.classList.add(`exam-${m[0].toLowerCase()}`);
     btn.onclick=()=>showExam(ex);

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,12 @@ button:hover { filter: brightness(1.2); }
   max-width:none; /* remove eventuais limites             */
 }
 
+/* Botões de simulados na tela "Provas e Simulados" */
+.exam-btn{
+  width:240px;
+  max-width:none;
+}
+
 .two-line-btn{
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- extend exam button width via `.exam-btn`
- apply new class when listing exams

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685f28d9200483218ccab250375a3e10