### PR TITLE
Add Poliedro simulado and avoid mobile zoom

### DIFF
--- a/main.js
+++ b/main.js
@@ -824,7 +824,7 @@ function showExamList(){
     const btn=document.createElement('button');
     btn.textContent=ex;
     btn.className='btn exam-btn';
-    const m=ex.match(/ENEM|SAS|BERNOULLI/i);
+    const m=ex.match(/ENEM|SAS|BERNOULLI|POLIEDRO/i);
     if(m) btn.classList.add(`exam-${m[0].toLowerCase()}`);
     btn.onclick=()=>showExam(ex);
     app.appendChild(btn);
@@ -864,7 +864,7 @@ function showExam(exam){
     qBtn.innerHTML=`<span class="ms-topic">${getFriendlyName(disc,sub)}</span><br><span class="ms-label">${q.label}</span>`;
     qBtn.classList.add('btn','question-btn','two-line-btn');
     qBtn.querySelector('.ms-topic').style.color=discColors[disc];
-    const m=q.label.match(/ENEM|SAS|BERNOULLI/i);
+    const m=q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO/i);
     if(m) qBtn.classList.add(`exam-${m[0].toLowerCase()}`);
     qBtn.onclick=()=>openPdf(q.QPDFName,q.page);
     row.appendChild(qBtn);
@@ -1036,7 +1036,7 @@ function showQuestions(disc, sub, fromStar = false) {
     qBtn.classList.add("btn");
 
     // detecta ENEM, SAS ou BERNOULLI no label
-    const m = q.label.match(/ENEM|SAS|BERNOULLI/i);
+    const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO/i);
     if (m) {
       const exam = m[0].toLowerCase();          // "enem", "sas" ou "bernoulli"
       qBtn.classList.add(`exam-${exam}`);       // .exam-enem / .exam-sas / .exam-bernoulli
@@ -1310,7 +1310,7 @@ function showMicroSim(entry) {
       <span class="ms-topic">${getFriendlyName(disc,sub)}</span><br>
       <span class="ms-label">${q.label}</span>`;
     qBtn.classList.add('btn','question-btn','two-line-btn');
-    const m = q.label.match(/ENEM|SAS|BERNOULLI/i);
+    const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO/i);
     if(m){
       const exam = m[0].toLowerCase();
       qBtn.classList.add(`exam-${exam}`);

--- a/styles.css
+++ b/styles.css
@@ -291,7 +291,7 @@ button:hover { filter: brightness(1.2); }
   border-radius: 4px;
   padding: 8px;
   margin: 8px 0 0 15px;
-  font-size: 14px;
+  font-size: 16px;
 }
 .comment-input::placeholder { color: var(--c-text-muted); }
 
@@ -457,12 +457,14 @@ button:hover { filter: brightness(1.2); }
   --c-exam-enem:       #AC1D22;
   --c-exam-sas:        #3774FF;
   --c-exam-bernoulli:  #00A98F;
+  --c-exam-poliedro:   #F7A407;
 }
 
 /* cada exame injeta a cor da faixa */
 .exam-enem       { --stripe-color: var(--c-exam-enem); }
 .exam-sas        { --stripe-color: var(--c-exam-sas); }
 .exam-bernoulli  { --stripe-color: var(--c-exam-bernoulli); }
+.exam-poliedro   { --stripe-color: var(--c-exam-poliedro); }
 
 /* === Botão Pomodoro === */
 #pomodoroBtn {
@@ -841,7 +843,7 @@ body.home #headerStats      { display: none !important; }      /* esconde estat�
   /* ─────────── Estilo visual ─────────── */
   background: var(--c-bg-panel);
   color: var(--c-text-primary);
-  font-size: 14px;
+  font-size: 16px;          /* evita zoom ao focar em dispositivos móveis */
   line-height: 1.4;
   border: 1px solid var(--c-border-muted);
   border-radius: 4px;
@@ -873,7 +875,7 @@ body.home #headerStats      { display: none !important; }      /* esconde estat�
 
   /* 3) espaçamento lateral e tamanho de fonte */
   padding: 0 6px;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 38px;       /* mesma altura de linha do .comment-edit */
   color: var(--c-text-muted);
   pointer-events: none;


### PR DESCRIPTION
## Summary
- bump comment input font size to prevent mobile zoom
- add "Poliedro" simulado color variables
- recognise the Poliedro simulado in exam buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f519b2a888321bdd8ea8f9e228633