### PR TITLE
Improve exam navigation and micro-sim style

### DIFF
--- a/main.js
+++ b/main.js
@@ -914,6 +914,7 @@ function renderExamSummary(){
 function showExamMenu(){
   currentDisc=currentSub=null;
   currentExam=null;
+  currentExamMode=null;
   examListOpen=true;
   leaveHome();
   toggleSettingsVisibility(false);
@@ -1438,6 +1439,7 @@ function showMicroSim(entry) {
       <span class="ms-topic">${getFriendlyName(disc,sub)}</span><br>
       <span class="ms-label">${q.label}</span>`;
     qBtn.classList.add('btn','question-btn','two-line-btn');
+    qBtn.querySelector('.ms-topic').style.color = discColors[disc];
     const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO/i);
     if(m){
       const exam = m[0].toLowerCase();
@@ -1681,8 +1683,12 @@ backBtn.onclick = () => {
     return;
   }
   if(examListOpen){
-    examListOpen=false;
-    showMenu();
+    if(currentExamMode){
+      showExamMenu();
+    } else {
+      examListOpen=false;
+      showMenu();
+    }
     return;
   }
   if(trailReturn){


### PR DESCRIPTION
## Summary
- color micro simulated topic names using discipline palette
- return from exam list to category menu before going to home

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866ceb06f0883218f7322b3fd19f629