### PR TITLE
Handle cancellation for math simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
       </div>
       <div class="picker-actions">
         <button id="pickerAdd">Adicionar</button>
-        <button id="pickerMicro" style="display:none;">Micro Simulado</button>
+        <button id="pickerMicro" style="display:none;">Simulado de Matemática</button>
         <button id="pickerCancel">Cancelar</button>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -770,6 +770,7 @@ function openPicker(callback){
       return;
     }
     const inp = prompt(`Quantas questões deseja? (1-${max})`, '10');
+    if(inp === null) return; // cancelado
     const n = Math.max(1, Math.min(parseInt(inp,10)||0, max));
     const qs = generateMicroQuestions(n);
     if(qs.length===0) return;
@@ -848,7 +849,7 @@ function renderTrailDay(day,expand){
 
       const isMicro = s.sub==='micro';
       const label = isMicro
-        ? 'Micro Simulado de Matemática'
+        ? 'Simulado de Matemática'
         : `${s.disc}: ${getFriendlyName(s.disc,s.sub)}`;
       const qcount = isMicro
         ? countMicroProgress(s)
@@ -1445,14 +1446,14 @@ if (imgContainer) {
   });
 }
 
-// --- Micro Simulado de Matemática (10 questões de assuntos aleatórios) ---
+// --- Simulado de Matemática (10 questões de assuntos aleatórios) ---
 function showMicroSim(entry) {
   currentDisc = 'Matemática';
   currentSub  = null;
   // mantém trailReturn para voltar à trilha corretamente
   leaveHome();
   toggleSettingsVisibility(false);
-  updateHeader(true, 'Micro Simulado de Matemática');
+  updateHeader(true, 'Simulado de Matemática');
   document.getElementById('headerStats').style.visibility='visible';
   clear();
   window.scrollTo(0,0);
@@ -1467,6 +1468,10 @@ function showMicroSim(entry) {
       return;
     }
     const inp = prompt(`Quantas questões deseja? (1-${max})`, '10');
+    if(inp === null){
+      backBtn.onclick();
+      return;
+    }
     const n = Math.max(1, Math.min(parseInt(inp,10)||0, max));
     micro = generateMicroQuestions(n);
   }


### PR DESCRIPTION
## Summary
- rename the Micro Simulado button/labels to **Simulado de Matemática**
- prevent creation of a simulation when the prompt is canceled in `showMicroSim`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6866d9b1d0648321956587ba935f4948