### PR TITLE
Implement summary buttons for subjects and disciplines

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,10 @@
       <button id="exportBtn">Exportar</button>
     </div>
     <div class="header-top">
-      <span id="headerTitle">Título Dinâmico</span>
+      <span id="headerTitle">Título Dinâmico
+        <span id="orderHint" class="order-hint" style="display:none"></span>
+      </span>
+      <button id="summaryBtn" class="summary-btn" style="display:none">Resumo</button>
     </div>
     <div class="header-bottom">
       <span id="headerStats" class="stat neutral">Estatísticas</span>

--- a/styles.css
+++ b/styles.css
@@ -343,6 +343,42 @@ button:hover { filter: brightness(1.2); }
   justify-content: center;
 }
 
+/* Botão de resumo no cabeçalho */
+.summary-btn {
+  all: unset;
+  margin-left: 4px;
+  padding: 0 6px;
+  height: 20px;
+  font-size: 10px;
+  border-radius: 4px;
+  background: #3a3a3a;
+  color: var(--c-text-muted);
+  border: 1px solid #555;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.summary-btn:hover {
+  filter: brightness(1.2);
+}
+
+#headerTitle {
+  position: relative;
+  display: inline-block;
+}
+
+.order-hint {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  color: var(--c-text-muted);
+  white-space: nowrap;
+}
+
 /* =====================================================================================
    VISUALIZAÇÃO DE PDF (LIGHTBOX)
    =====================================================================================*/


### PR DESCRIPTION
## Summary
- add `summaryBtn` element and new order hint span in the header
- style new summary button and order hint
- display "Resumão" button in the discipline view and toggle ordering by tapping the title
- display "Resumo" button inside subjects instead of using the title
- hide summary button on the home screen
- refine summary button size and order hint placement
- show summary button only for Física and Matemática
- reduce header summary button font size

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6867310f3ca483218dc3c578dd6f6126