### PR TITLE
Add exam option to Trilha selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,8 @@
       <div class="picker-row">
         <select id="pickerDisc"></select>
         <select id="pickerSub"></select>
+        <select id="pickerExamMode" style="display:none;"></select>
+        <select id="pickerExam" style="display:none;"></select>
         <input id="pickerComment" type="text" placeholder="Comentário" style="display:none;"/>
       </div>
       <div class="picker-actions">

--- a/main.js
+++ b/main.js
@@ -731,6 +731,10 @@ function openPicker(callback){
     opt.textContent = d;
     pickerDisc.appendChild(opt);
   }
+  const optExam=document.createElement('option');
+  optExam.value='__exams__';
+  optExam.textContent='Provas e Simulados';
+  pickerDisc.appendChild(optExam);
   const optComment=document.createElement('option');
   optComment.value='__comment__';
   optComment.textContent='Comentário';
@@ -739,6 +743,10 @@ function openPicker(callback){
     if(pickerDisc.value==='__comment__'){
       pickerSub.style.display='none';
       pickerComment.style.display='inline-block';
+      pickerMicro.style.display='none';
+    }else if(pickerDisc.value==='__exams__'){
+      pickerSub.style.display='none';
+      pickerComment.style.display='none';
       pickerMicro.style.display='none';
     }else{
       pickerSub.style.display='';
@@ -760,6 +768,8 @@ function openPicker(callback){
       const txt=pickerComment.value.trim();
       if(txt) callback({comment:txt});
       pickerComment.value='';
+    }else if(pickerDisc.value==='__exams__'){
+      callback({examMenu:true});
     }else{
       callback({disc: pickerDisc.value, sub: pickerSub.value});
     }
@@ -835,6 +845,25 @@ function renderTrailDay(day,expand){
             showTrail(dayStr, true);
           }
         };
+        const rm=document.createElement('button');
+        rm.className='trail-remove';
+        rm.textContent='\u00D7';
+        rm.onclick=()=>{
+          data[key].splice(idx,1);
+          saveTrail(dayStr,data);
+          showTrail(dayStr, true);
+        };
+        item.appendChild(subj);
+        item.appendChild(rm);
+        sec.appendChild(item);
+        return;
+      }
+
+      if(s.examMenu){
+        const subj=document.createElement('button');
+        subj.className='trail-subject';
+        subj.textContent='Provas e Simulados';
+        subj.onclick=()=>{ trailReturn=dayStr; showExamMenu(); };
         const rm=document.createElement('button');
         rm.className='trail-remove';
         rm.textContent='\u00D7';

--- a/main.js
+++ b/main.js
@@ -149,6 +149,8 @@ const examsBtn     = document.getElementById("examsBtn");
 const pickerModal   = document.getElementById("subjectPickerModal");
 const pickerDisc    = document.getElementById("pickerDisc");
 const pickerSub     = document.getElementById("pickerSub");
+const pickerExamMode= document.getElementById("pickerExamMode");
+const pickerExam    = document.getElementById("pickerExam");
 const pickerComment = document.getElementById("pickerComment");
 const pickerAdd     = document.getElementById("pickerAdd");
 const pickerMicro   = document.getElementById("pickerMicro");
@@ -725,6 +727,10 @@ function countMicroProgress(entry){
 function openPicker(callback){
   pickerDisc.innerHTML = '';
   pickerSub.innerHTML  = '';
+  pickerExamMode.innerHTML='';
+  pickerExam.innerHTML='';
+  pickerExamMode.style.display='none';
+  pickerExam.style.display='none';
   for(const d of Object.keys(SUBJECT_NAMES)){
     const opt = document.createElement('option');
     opt.value = d;
@@ -744,10 +750,27 @@ function openPicker(callback){
       pickerSub.style.display='none';
       pickerComment.style.display='inline-block';
       pickerMicro.style.display='none';
+      pickerExamMode.style.display='none';
+      pickerExam.style.display='none';
     }else if(pickerDisc.value==='__exams__'){
       pickerSub.style.display='none';
       pickerComment.style.display='none';
       pickerMicro.style.display='none';
+      pickerExamMode.style.display='';
+      pickerExam.style.display='';
+      pickerExamMode.innerHTML='<option value="nat">Natureza</option><option value="mat">Matemática</option>';
+      const populateExam=()=>{
+        const order=pickerExamMode.value==='mat'? examOrderMat : examOrderNat;
+        pickerExam.innerHTML='';
+        order.forEach(ex=>{
+          const o=document.createElement('option');
+          o.value=ex;
+          o.textContent=ex;
+          pickerExam.appendChild(o);
+        });
+      };
+      pickerExamMode.onchange=populateExam;
+      populateExam();
     }else{
       pickerSub.style.display='';
       pickerComment.style.display='none';
@@ -760,6 +783,8 @@ function openPicker(callback){
       });
       pickerMicro.style.display =
         pickerDisc.value==='Matemática'? 'inline-block' : 'none';
+      pickerExamMode.style.display='none';
+      pickerExam.style.display='none';
     }
   };
   pickerDisc.onchange();
@@ -769,7 +794,7 @@ function openPicker(callback){
       if(txt) callback({comment:txt});
       pickerComment.value='';
     }else if(pickerDisc.value==='__exams__'){
-      callback({examMenu:true});
+      callback({exam:pickerExam.value,mode:pickerExamMode.value});
     }else{
       callback({disc: pickerDisc.value, sub: pickerSub.value});
     }
@@ -859,11 +884,13 @@ function renderTrailDay(day,expand){
         return;
       }
 
-      if(s.examMenu){
+      if(s.exam){
         const subj=document.createElement('button');
         subj.className='trail-subject';
-        subj.textContent='Provas e Simulados';
-        subj.onclick=()=>{ trailReturn=dayStr; showExamMenu(); };
+        subj.textContent=s.exam;
+        const m=s.exam.match(/ENEM|SAS|BERNOULLI|POLIEDRO/i);
+        if(m) subj.classList.add(`exam-${m[0].toLowerCase()}`);
+        subj.onclick=()=>{ trailReturn=dayStr; currentExamMode=s.mode; showExam(s.exam); };
         const rm=document.createElement('button');
         rm.className='trail-remove';
         rm.textContent='\u00D7';
@@ -1823,8 +1850,15 @@ importFile.addEventListener("change", ({ target }) => {
 /* Botão Voltar → decide se volta à lista de assuntos, trilha ou menu */
 backBtn.onclick = () => {
   if(currentExam){
-    currentExam=null;
-    showExamList(currentExamMode);
+    if(trailReturn){
+      const d=trailReturn;
+      currentExam=null;
+      trailReturn=null;
+      showTrail(d);
+    }else{
+      currentExam=null;
+      showExamList(currentExamMode);
+    }
     return;
   }
   if(examListOpen){


### PR DESCRIPTION
## Summary
- allow adding "Provas e Simulados" from the Trilha Estratégica selector
- open the exam menu when the new item is clicked

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_68752eed00d08321a02458551f49afcb