### PR TITLE
Destacar simulados na trilha

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -829,6 +829,11 @@ button:hover { filter: brightness(1.2); }
 .trail-subject.fisica     { background: var(--c-fis); }
 .trail-subject.matematica { background: var(--c-mat); }
 .trail-subject.d1         { background: var(--c-d1); }
+/* Exams */
+.trail-subject.exam-enem      { background: var(--c-exam-enem); }
+.trail-subject.exam-sas       { background: var(--c-exam-sas); }
+.trail-subject.exam-bernoulli { background: var(--c-exam-bernoulli); }
+.trail-subject.exam-poliedro  { background: var(--c-exam-poliedro); }
 
 .trail-comment {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- colorir os simulados adicionados na Trilha Estratégica

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6875346cb8648321bb05be2c057ae934