### PR TITLE
Update D1 interface and add degree symbol

### DIFF
--- a/Editor_de_Texto.html
+++ b/Editor_de_Texto.html
@@ -289,7 +289,7 @@ const SUB_MAP = {
   'a':'ₐ','e':'ₑ','o':'ₒ','x':'ₓ','h':'ₕ','k':'ₖ','l':'ₗ','m':'ₘ','n':'ₙ','p':'ₚ','s':'ₛ','t':'ₜ'
 };
 
-const UNICODE_SYMBOLS = ["→","⇌","√","∛","≈","≠","×","±","Δ","θ","π","λ","σ","Ω","μ"];
+const UNICODE_SYMBOLS = ["→","⇌","√","∛","≈","≠","×","±","Δ","θ","π","λ","σ","Ω","μ","°"];
 
 UNICODE_SYMBOLS.forEach(sym=>{
   const b=document.createElement('button');

--- a/main.js
+++ b/main.js
@@ -624,26 +624,16 @@ function showMenu () {
         textContent: disc,
         onclick: () => showSubjects(disc),
       }));
-    const stars = line.appendChild(Object.assign(
-      document.createElement("div"), { className: "stars-container" }));
-    for (const sub of Object.keys(questoesData[disc]).sort()) {
-      const star = stars.appendChild(Object.assign(
-        document.createElement("span"), { className: "star" }));
-      star.innerHTML = `<span class="star-index">${sub}</span>`;
-      let st;
-      if (disc === 'D1') {
-        st = +localStorage.getItem(`d1_star_${sub}`) || 0;
-      } else {
-        st = calcStarState(disc, sub);
-      }
-      updateStar(star, st);
-      if (disc === 'D1') {
-        star.onclick = () => {
-          st = (st + 1) % 5;
-          localStorage.setItem(`d1_star_${sub}`, st);
-          updateStar(star, st);
-        };
-      } else {
+
+    if (disc !== 'D1') {
+      const stars = line.appendChild(Object.assign(
+        document.createElement("div"), { className: "stars-container" }));
+      for (const sub of Object.keys(questoesData[disc]).sort()) {
+        const star = stars.appendChild(Object.assign(
+          document.createElement("span"), { className: "star" }));
+        star.innerHTML = `<span class="star-index">${sub}</span>`;
+        let st = calcStarState(disc, sub);
+        updateStar(star, st);
         star.onclick = () => {
           showQuestions(disc, sub, true); // se veio da estrela, volta para Home
         };
@@ -1207,7 +1197,13 @@ function showSubjects(disc) {
       : pct >= 60 ? "stat orange"
       : "stat red";
   }
-  refreshDiscStats();
+  if (disc === 'D1') {
+    statDiv.style.visibility = 'hidden';
+    statDiv.textContent = '';
+  } else {
+    statDiv.style.visibility = 'visible';
+    refreshDiscStats();
+  }
 
   // 5) Monta a lista de assuntos na ordem certa
   let subs = Object.keys(questoesData[disc]);
@@ -1227,15 +1223,25 @@ function showSubjects(disc) {
       document.createElement("button"), {
         className: "subject-btn",
         textContent: getFriendlyName(disc, sub),
-        onclick: () => showQuestions(disc, sub)
+        onclick: () => {
+          if (disc === 'D1') {
+            currentDisc = disc;
+            currentSub = sub;
+            openSummary();
+          } else {
+            showQuestions(disc, sub);
+          }
+        }
       }
     ));
 
-    // badge de ranking de incidência
-    btn.insertAdjacentHTML("beforeend",
-      `<span class="subject-badge-rect">
-         ${INCIDENCE_RANKINGS[disc]?.[sub]||""}
-       </span>`);
+    if (disc !== 'D1') {
+      // badge de ranking de incidência
+      btn.insertAdjacentHTML("beforeend",
+        `<span class="subject-badge-rect">
+           ${INCIDENCE_RANKINGS[disc]?.[sub]||""}
+         </span>`);
+    }
 
     // faixa de cor de desempenho
     const qs = questoesData[disc][sub];


### PR DESCRIPTION
## Summary
- remove star rating display for the `D1` discipline
- hide performance stats and ranking badge when viewing D1 topics
- open the text summary directly when selecting a D1 topic
- extend unicode menu with the `°` symbol

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e6fdc4be883219e26782d6aa51ea0