### PR TITLE
Add D1 answer modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,13 @@
     <img id="imgPreview" alt="imagem" />
   </div>
   <!-- =====================================================================
+       MODAL DE GABARITO
+       - Exibe apenas a letra do gabarito
+       ===================================================================== -->
+  <div id="answerModal">
+    <div id="answerBox"></div>
+  </div>
+  <!-- =====================================================================
      RESUMO (overlay com o editor de texto)
      ===================================================================== -->
   <div id="summaryContainer" style="position:fixed;inset:0;background:#121212;display:none;flex-direction:column;z-index:2000;">

--- a/main.js
+++ b/main.js
@@ -247,6 +247,8 @@ const closeBtn     = document.getElementById("closePdfBtn");
 const imgContainer = document.getElementById("imgPreviewContainer");
 const closeImgBtn  = document.getElementById("closeImgBtn");
 const previewImg   = document.getElementById("imgPreview");
+const answerModal  = document.getElementById("answerModal");
+const answerBox    = document.getElementById("answerBox");
 const summaryContainer = document.getElementById("summaryContainer");
 const summaryFrame     = document.getElementById("summaryFrame");
 
@@ -1256,7 +1258,17 @@ function showExam(exam){
       }
     });
     row.appendChild(qBtn);
-    row.appendChild(Object.assign(document.createElement('button'),{textContent:'Gabarito',className:'small-btn',onclick:()=>openPdf(q.GPDFName,q.gabaritoPage)}));
+    row.appendChild(Object.assign(document.createElement('button'), {
+      textContent: 'Gabarito',
+      className: 'small-btn',
+      onclick: () => {
+        if (q.gabaritoAnswer) {
+          openAnswer(q.gabaritoAnswer);
+        } else {
+          openPdf(q.GPDFName, q.gabaritoPage);
+        }
+      }
+    }));
     const key=qKey(disc,sub,q.label);
     let st=+localStorage.getItem(key)||0;
     const box=row.appendChild(Object.assign(document.createElement('span'),{className:'state-box'}));
@@ -1468,8 +1480,17 @@ function showQuestions(disc, sub, fromStar = false) {
 
     /* Botão gabarito */
     row.appendChild(Object.assign(
-      document.createElement("button"), { textContent:"Gabarito", className:"small-btn",
-      onclick: () => openPdf(q.GPDFName, q.gabaritoPage) }));
+      document.createElement("button"), {
+        textContent: "Gabarito",
+        className: "small-btn",
+        onclick: () => {
+          if (q.gabaritoAnswer) {
+            openAnswer(q.gabaritoAnswer);
+          } else {
+            openPdf(q.GPDFName, q.gabaritoPage);
+          }
+        }
+      }));
 
     /* Caixa ✓ / ✗ */
     const key    = qKey(disc, sub, q.label);          // estado ✓/✗
@@ -1683,6 +1704,24 @@ if (imgContainer) {
   });
 }
 
+function openAnswer(letter) {
+  if (!answerBox) {
+    alert(`Gabarito: ${letter}`);
+    return;
+  }
+  answerBox.textContent = letter;
+  answerModal.style.display = 'flex';
+}
+function closeAnswer(){
+  answerModal.style.display = 'none';
+  if (answerBox) answerBox.textContent = '';
+}
+if (answerModal) {
+  answerModal.addEventListener('click', e => {
+    if (e.target === answerModal) closeAnswer();
+  });
+}
+
 // --- Simulado de Matemática (10 questões de assuntos aleatórios) ---
 function showMicroSim(entry) {
   currentDisc = 'Matemática';
@@ -1760,8 +1799,17 @@ function showMicroSim(entry) {
     row.appendChild(qBtn);
 
     row.appendChild(Object.assign(
-      document.createElement('button'),{textContent:'Gabarito',className:'small-btn',
-      onclick:()=>openPdf(q.GPDFName,q.gabaritoPage)}));
+      document.createElement('button'), {
+        textContent: 'Gabarito',
+        className: 'small-btn',
+        onclick: () => {
+          if (q.gabaritoAnswer) {
+            openAnswer(q.gabaritoAnswer);
+          } else {
+            openPdf(q.GPDFName, q.gabaritoPage);
+          }
+        }
+      }));
 
     const key = qKey(disc,sub,q.label);
     let st = +localStorage.getItem(key)||0;

--- a/styles.css
+++ b/styles.css
@@ -462,6 +462,28 @@ button:hover { filter: brightness(1.2); }
   background: rgba(30, 30, 30, .90);
   transform: scale(1.1);
 }
+
+/* =====================================================================
+   MODAL DE GABARITO
+   ===================================================================== */
+#answerModal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+#answerBox {
+  background: #1e1e1e;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 24px 32px;
+  color: #e6edf3;
+  font-size: 32px;
+  font-weight: bold;
+}
 /* ───────── Botão stripe ───────── */
 .btn {
   position: relative;


### PR DESCRIPTION
## Summary
- add answer modal markup
- style answer modal
- show answer letter when available instead of opening PDF
- add helper to open/close answer modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e8ceaaf5883219f37ad3b43d5577f