### PR TITLE
Fix trail navigation and timezone usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -2093,9 +2093,13 @@ backBtn.onclick = () => {
     return;
   }
   if(trailReturn){
-    const d = trailReturn;
-    trailReturn = null;
-    showTrail(d);
+    if(currentSub){
+      showSubjects(currentDisc);
+    } else {
+      const d = trailReturn;
+      trailReturn = null;
+      showTrail(d);
+    }
   }else if(starReturn){
     starReturn = false;
     showMenu();
@@ -2370,7 +2374,8 @@ window.addEventListener('focus', resumePomodoroIfNeeded);
     const counts = [];
     for(let i=0;i<7;i++){
       const d = new Date(monday.getTime() + i*DAY_MS);
-      counts.push( countXpOn(d.toISOString().slice(0,10)) );
+      const dStr = d.toLocaleDateString('en-CA',{timeZone:'America/Fortaleza'});
+      counts.push( countXpOn(dStr) );
     }
     return { labels, counts };
   }
@@ -2378,9 +2383,11 @@ window.addEventListener('focus', resumePomodoroIfNeeded);
   /* ---------- Média móvel dos últimos 7 dias ---------- */
   function last7DaysAvg(){
     let sum=0;
+    const today = getTodayDateBR();
     for(let i=0;i<7;i++){
-      const d = new Date(Date.now() - i*DAY_MS);
-      sum += countXpOn(d.toISOString().slice(0,10));
+      const d = new Date(today.getTime() - i*DAY_MS);
+      const dStr = d.toLocaleDateString('en-CA',{timeZone:'America/Fortaleza'});
+      sum += countXpOn(dStr);
     }
     return sum/7;
   }


### PR DESCRIPTION
## Summary
- refine back button logic so returning from subjects opened via the trail goes to the discipline list first
- compute XP data using Brazil time for the weekly summary

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_687fc65d5c7c8321a7dabbb9bfb06647