### PR TITLE
Add Evolucional bank color mapping

### DIFF
--- a/main.js
+++ b/main.js
@@ -1126,7 +1126,7 @@ function renderTrailDay(day,expand){
           const subj=document.createElement('button');
           subj.className='trail-subject';
           subj.textContent=s.exam;
-          const m=s.exam.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS/i);
+          const m=s.exam.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS|EVOLUCIONAL/i);
           if(m) subj.classList.add(`exam-${m[0].toLowerCase()}`);
         subj.onclick=()=>{ trailReturn=dayStr; currentExamMode=s.mode; showExam(s.exam); };
         const rm=document.createElement('button');
@@ -1324,7 +1324,7 @@ function showExamList(mode='nat'){
     const btn=document.createElement('button');
     btn.textContent=ex;
     btn.className='btn exam-btn';
-    const m=ex.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS/i);
+    const m=ex.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS|EVOLUCIONAL/i);
     if(m) btn.classList.add(`exam-${m[0].toLowerCase()}`);
     btn.onclick=()=>showExam(ex);
     app.appendChild(btn);
@@ -1366,7 +1366,7 @@ function showExam(exam){
     qBtn.classList.add('btn','question-btn','two-line-btn');
     const topicSpan=qBtn.querySelector('.ms-topic');
     topicSpan.style.color=discColors[disc];
-    const m=q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS/i);
+    const m=q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS|EVOLUCIONAL/i);
     if(m) qBtn.classList.add(`exam-${m[0].toLowerCase()}`);
     qBtn.addEventListener('click',e=>{
       if(e.target.closest('.ms-topic')){
@@ -1590,11 +1590,11 @@ function showQuestions(disc, sub, fromStar = false, fromTrailSub = false) {
     qBtn.textContent = q.label;
     qBtn.classList.add("btn");
 
-    // detecta ENEM, SAS, BERNOULLI, POLIEDRO ou SOMOS no label
-    const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS/i);
+    // detecta ENEM, SAS, BERNOULLI, POLIEDRO, SOMOS ou EVOLUCIONAL no label
+    const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS|EVOLUCIONAL/i);
     if (m) {
-      const exam = m[0].toLowerCase();          // "enem", "sas", "bernoulli", "poliedro" ou "somos"
-      qBtn.classList.add(`exam-${exam}`);       // .exam-enem / .exam-sas / .exam-bernoulli / .exam-poliedro / .exam-somos
+      const exam = m[0].toLowerCase();          // "enem", "sas", "bernoulli", "poliedro", "somos" ou "evolucional"
+      qBtn.classList.add(`exam-${exam}`);       // .exam-enem / .exam-sas / .exam-bernoulli / .exam-poliedro / .exam-somos / .exam-evolucional
     }
 
     qBtn.onclick = () => openPdf(q.QPDFName, q.page);
@@ -1918,7 +1918,7 @@ function showMicroSim(entry) {
       <span class="ms-label">${q.label}</span>`;
     qBtn.classList.add('btn','question-btn','two-line-btn');
     qBtn.querySelector('.ms-topic').style.color = discColors[disc];
-    const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS/i);
+    const m = q.label.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS|EVOLUCIONAL/i);
     if(m){
       const exam = m[0].toLowerCase();
       qBtn.classList.add(`exam-${exam}`);

--- a/styles.css
+++ b/styles.css
@@ -504,6 +504,7 @@ button:hover { filter: brightness(1.2); }
   --c-exam-bernoulli:  #00A98F;
   --c-exam-poliedro:   #F7A407;
   --c-exam-somos:      #E31C79;
+  --c-exam-evolucional:#060181;
 }
 
 /* cada exame injeta a cor da faixa */
@@ -512,6 +513,7 @@ button:hover { filter: brightness(1.2); }
 .exam-bernoulli  { --stripe-color: var(--c-exam-bernoulli); }
 .exam-poliedro   { --stripe-color: var(--c-exam-poliedro); }
 .exam-somos      { --stripe-color: var(--c-exam-somos); }
+.exam-evolucional{ --stripe-color: var(--c-exam-evolucional); }
 
 /* === Botão Pomodoro === */
 #pomodoroBtn {


### PR DESCRIPTION
## Summary
- add CSS variable and stripe class for Evolucional exams using color `#060181`
- include Evolucional in JavaScript exam detection patterns

## Testing
- `node --check main.js`
- `npx --yes stylelint styles.css` *(fails: No configuration provided for styles.css)*

------
https://chatgpt.com/codex/tasks/task_e_689b903e1a888321aeacf16d7ada0f3e