### PR TITLE
Ajusta ordenação e exibição para D1 e simulados

### DIFF
--- a/main.js
+++ b/main.js
@@ -393,6 +393,32 @@ function buildExamMap(list, mode='nat'){
       return na-nb;
     });
   }
+  if(mode === 'lin' || mode === 'hum'){
+    const typePriority = { REG:1, PPL:2, DIG:3 };
+    order.sort((a,b)=>{
+      const pa=a.split('-');
+      const pb=b.split('-');
+      const bancaA=pa[0].toLowerCase();
+      const bancaB=pb[0].toLowerCase();
+      if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
+      const yearA=parseInt(pa[1],10);
+      const yearB=parseInt(pb[1],10);
+      if(yearA!==yearB) return yearA-yearB;
+      if(bancaA==='enem'){
+        const ta=pa[2]||'';
+        const tb=pb[2]||'';
+        const va=typePriority[ta]||99;
+        const vb=typePriority[tb]||99;
+        if(va!==vb) return va-vb;
+      }
+      const restA=pa.slice(2).join('-');
+      const restB=pb.slice(2).join('-');
+      const na=parseInt(restA,10);
+      const nb=parseInt(restB,10);
+      if(!isNaN(na) && !isNaN(nb)) return na-nb;
+      return restA.localeCompare(restB);
+    });
+  }
   return { map: exams, order };
 }
 
@@ -798,19 +824,17 @@ function showMenu () {
     if(disc === 'Geografia e Sociologia') btn.style.padding='0 4px';
     line.appendChild(btn);
 
-    if (!D1_DISCIPLINES.includes(disc)) {
-      const stars = line.appendChild(Object.assign(
-        document.createElement("div"), { className: "stars-container" }));
-      for (const sub of Object.keys(questoesData[disc]).sort()) {
-        const star = stars.appendChild(Object.assign(
-          document.createElement("span"), { className: "star" }));
-        star.innerHTML = `<span class="star-index">${sub}</span>`;
-        let st = calcStarState(disc, sub);
-        updateStar(star, st);
-        star.onclick = () => {
-          showQuestions(disc, sub, true, false); // se veio da estrela, volta para Home
-        };
-      }
+    const stars = line.appendChild(Object.assign(
+      document.createElement("div"), { className: "stars-container" }));
+    for (const sub of Object.keys(questoesData[disc]).sort()) {
+      const star = stars.appendChild(Object.assign(
+        document.createElement("span"), { className: "star" }));
+      star.innerHTML = `<span class="star-index">${sub}</span>`;
+      let st = calcStarState(disc, sub);
+      updateStar(star, st);
+      star.onclick = () => {
+        showQuestions(disc, sub, true, false); // se veio da estrela, volta para Home
+      };
     }
   }
   toggleSettingsVisibility(true);   // mostra engrenagem
@@ -961,7 +985,6 @@ function openPicker(callback){
   pickerExamMode.style.display='none';
   pickerExam.style.display='none';
   for(const d of Object.keys(SUBJECT_NAMES)){
-    if(!d1Enabled && D1_DISCIPLINES.includes(d)) continue;
     const opt = document.createElement('option');
     opt.value = d;
     opt.textContent = d;
@@ -1265,7 +1288,6 @@ function showTrail(expandDay, preserveScroll=false){
     const open=openTrailDays.has(dStr);
     renderTrailDay(new Date(d), open);
   }
-  renderExamSummary();
   if(preserveScroll) window.scrollTo(0,prevY);
 }
 
@@ -1366,6 +1388,7 @@ function showExamMenu(){
   app.appendChild(btnHum);
   app.appendChild(btnNat);
   app.appendChild(btnMat);
+  renderExamSummary();
 }
 
 function showExamList(mode='nat'){

--- a/styles.css
+++ b/styles.css
@@ -30,7 +30,7 @@
   --c-qui:  #0093D6;
   --c-fis:  #904992;
   --c-mat:  #F5821F;
-  --c-d1:   var(--c-bg-panel);
+  --c-d1:   #F5C500;
 }
 
 /* =====================================================================================
@@ -227,7 +227,7 @@ button:hover { filter: brightness(1.2); }
 .disc-btn.quimica    { background: var(--c-qui); }
 .disc-btn.fisica     { background: var(--c-fis); }
 .disc-btn.matematica { background: var(--c-mat); }
-.disc-btn.d1         { background: var(--c-d1); }
+.disc-btn.d1         { background: var(--c-d1); color:#000; }
 
 /* =====================================================================================
    ESTRELAS DE PROGRESSO
@@ -775,10 +775,18 @@ button:hover { filter: brightness(1.2); }
 
 #examSummary {
   margin-top: 20px;
+  padding: 10px;
+  background: var(--c-bg-panel);
+  border-radius: 8px;
+}
+#examSummary h3 {
+  text-align: center;
+  margin-bottom: 8px;
 }
 
 .exam-row {
   display: flex;
+  justify-content: space-between;
   gap: 12px;
   padding: 4px 0;
 }
@@ -848,7 +856,7 @@ button:hover { filter: brightness(1.2); }
 .trail-subject.quimica    { background: var(--c-qui); }
 .trail-subject.fisica     { background: var(--c-fis); }
 .trail-subject.matematica { background: var(--c-mat); }
-.trail-subject.d1         { background: #F5C500; }
+.trail-subject.d1         { background: var(--c-d1); }
 /* Exams */
 .trail-subject.exam-enem      { background: var(--c-exam-enem); }
 .trail-subject.exam-sas       { background: var(--c-exam-sas); }


### PR DESCRIPTION
## Resumo
- Exibe estrelas também para disciplinas do D1 e permite adicionar seus assuntos mesmo com o D1 oculto na Home
- Reordena provas de Linguagens e Humanas por banca, ano e tipo prioritário (REG, PPL, DIG)
- Move o resumo por simulado para a tela de Provas e Simulados e aplica estilo/cores do D1

## Testes
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_689bb690e2408321a32c0482626a61dc