### PR TITLE
Ajustes visuais e de layout em estrelas e simulados

### DIFF
--- a/main.js
+++ b/main.js
@@ -607,6 +607,7 @@ function calcStarState(disc, sub) {
     if (st === 1 || st === 2) answered++;
   });
   const total = qs.length;
+  if (total === 0) return 0; // nenhuma questão cadastrada
   if (answered < 10 && answered / total < 0.75) return 0; // ainda sem dados suficientes
   const pct = answered ? correct / answered : 0;
   return pct >= 0.9 ? 4
@@ -824,17 +825,19 @@ function showMenu () {
     if(disc === 'Geografia e Sociologia') btn.style.padding='0 4px';
     line.appendChild(btn);
 
-    const stars = line.appendChild(Object.assign(
-      document.createElement("div"), { className: "stars-container" }));
-    for (const sub of Object.keys(questoesData[disc]).sort()) {
-      const star = stars.appendChild(Object.assign(
-        document.createElement("span"), { className: "star" }));
-      star.innerHTML = `<span class="star-index">${sub}</span>`;
-      let st = calcStarState(disc, sub);
-      updateStar(star, st);
-      star.onclick = () => {
-        showQuestions(disc, sub, true, false); // se veio da estrela, volta para Home
-      };
+    if (disc !== 'Redação') {
+      const stars = line.appendChild(Object.assign(
+        document.createElement("div"), { className: "stars-container" }));
+      for (const sub of Object.keys(questoesData[disc]).sort()) {
+        const star = stars.appendChild(Object.assign(
+          document.createElement("span"), { className: "star" }));
+        star.innerHTML = `<span class="star-index">${sub}</span>`;
+        let st = calcStarState(disc, sub);
+        updateStar(star, st);
+        star.onclick = () => {
+          showQuestions(disc, sub, true, false); // se veio da estrela, volta para Home
+        };
+      }
     }
   }
   toggleSettingsVisibility(true);   // mostra engrenagem
@@ -1320,7 +1323,17 @@ function renderExamSummary(){
   const exams=computeExamStats();
   const container=document.createElement('div');
   container.id='examSummary';
-  container.innerHTML='<h3>Resumo por Simulado</h3>';
+  container.innerHTML='<h3>Desempenho por Simulado</h3>';
+  const table=document.createElement('table');
+  table.className='exam-summary-table';
+  const header=document.createElement('tr');
+  ['Banca','Linguagens','Humanas','Natureza','Matemática'].forEach(t=>{
+    const th=document.createElement('th');
+    th.textContent=t;
+    header.appendChild(th);
+  });
+  table.appendChild(header);
+  const tbody=document.createElement('tbody');
   const order=[...new Set([
     ...examOrderLin,
     ...examOrderHum,
@@ -1330,28 +1343,32 @@ function renderExamSummary(){
   order.forEach(exam=>{
     const data=exams[exam];
     if(!data) return;
-    const row=document.createElement('div');
-    row.className='exam-row';
-    const label=document.createElement('span');
-    label.className='exam-label';
-    label.textContent=exam;
-    row.appendChild(label);
+    const tr=document.createElement('tr');
+    const tdLabel=document.createElement('td');
+    const btn=document.createElement('button');
+    btn.textContent=exam;
+    btn.className='exam-summary-exam';
+    const m=exam.match(/ENEM|SAS|BERNOULLI|POLIEDRO|SOMOS|EVOLUCIONAL/i);
+    if(m) btn.classList.add(`exam-${m[0].toLowerCase()}`);
+    btn.onclick=()=>showExam(exam);
+    tdLabel.appendChild(btn);
+    tr.appendChild(tdLabel);
     const cats=[
-      ['Lin','Lin'],
-      ['Hum','Hum'],
-      ['Nat','Nat'],
-      ['Mat','Mat']
+      ['Lin','Linguagens'],
+      ['Hum','Humanas'],
+      ['Nat','Natureza'],
+      ['Mat','Matemática']
     ];
-    cats.forEach(([key, title])=>{
+    cats.forEach(([key])=>{
+      const td=document.createElement('td');
       const d=data[key];
-      if(d && d.t){
-        const s=document.createElement('span');
-        s.textContent=`${title}: ${d.c}/${d.a} de ${d.t}`;
-        row.appendChild(s);
-      }
+      td.textContent=d && d.t ? `${d.c}/${d.a} de ${d.t}` : '-';
+      tr.appendChild(td);
     });
-    container.appendChild(row);
+    tbody.appendChild(tr);
   });
+  table.appendChild(tbody);
+  container.appendChild(table);
   app.appendChild(container);
 }
 /* ---------------- LISTA DE ASSUNTOS ---------------- */
@@ -1398,7 +1415,8 @@ function showExamList(mode='nat'){
   currentExamMode=mode;
   leaveHome();
   toggleSettingsVisibility(false);
-  updateHeader(true,'Provas e Simulados');
+  const areaTitles={lin:'Linguagens',hum:'Humanas',nat:'Natureza',mat:'Matemática'};
+  updateHeader(true,`Provas e Simulados - ${areaTitles[mode] || ''}`);
   const stats=document.getElementById('headerStats');
   stats.style.visibility='hidden';
   clear();

--- a/styles.css
+++ b/styles.css
@@ -227,7 +227,7 @@ button:hover { filter: brightness(1.2); }
 .disc-btn.quimica    { background: var(--c-qui); }
 .disc-btn.fisica     { background: var(--c-fis); }
 .disc-btn.matematica { background: var(--c-mat); }
-.disc-btn.d1         { background: var(--c-d1); color:#000; }
+.disc-btn.d1         { background: var(--c-d1); color:#fff; }
 
 /* =====================================================================================
    ESTRELAS DE PROGRESSO
@@ -783,17 +783,36 @@ button:hover { filter: brightness(1.2); }
   text-align: center;
   margin-bottom: 8px;
 }
+#examSummary table {
+  width: 100%;
+  border-collapse: collapse;
+}
 
-.exam-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 4px 0;
+.exam-summary-table th,
+.exam-summary-table td {
+  text-align: center;
+  padding: 4px;
 }
-.exam-label {
-  flex: 0 0 150px;
-  font-weight: bold;
+
+.exam-summary-table th:first-child,
+.exam-summary-table td:first-child {
+  text-align: left;
 }
+
+.exam-summary-exam {
+  border: none;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.exam-summary-exam.exam-enem       { background: var(--c-exam-enem); }
+.exam-summary-exam.exam-sas        { background: var(--c-exam-sas); }
+.exam-summary-exam.exam-bernoulli  { background: var(--c-exam-bernoulli); }
+.exam-summary-exam.exam-poliedro   { background: var(--c-exam-poliedro); }
+.exam-summary-exam.exam-somos      { background: var(--c-exam-somos); }
+.exam-summary-exam.exam-evolucional{ background: var(--c-exam-evolucional); }
 
 /* Items */
 .trail-item {


### PR DESCRIPTION
## Summary
- Ajusta cálculo das estrelas para exibir preto em tópicos sem questões e remove estrelas da disciplina Redação
- Define texto branco para disciplinas do D1 e personaliza cabeçalho de Provas e Simulados por área
- Renomeia o Resumo por Simulado para Desempenho por Simulado com tabela e botões coloridos por banca

## Testing
- `npm test` *(falhou: Could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689bbe36490883219c9c03697a97dfff