### PR TITLE
Remove exam summary titles and add overall stats

### DIFF
--- a/main.js
+++ b/main.js
@@ -1323,17 +1323,18 @@ function renderExamSummary(){
   const exams=computeExamStats();
   const container=document.createElement('div');
   container.id='examSummary';
-  container.innerHTML='<h3>Desempenho por Simulado</h3>';
+  container.innerHTML='';
   const table=document.createElement('table');
   table.className='exam-summary-table';
   const header=document.createElement('tr');
-  ['Banca','Linguagens','Humanas','Natureza','Matemática'].forEach(t=>{
+  ['','Linguagens','Humanas','Natureza','Matemática'].forEach(t=>{
     const th=document.createElement('th');
     th.textContent=t;
     header.appendChild(th);
   });
   table.appendChild(header);
   const tbody=document.createElement('tbody');
+  let totalC=0,totalA=0;
   const order=[...new Set([
     ...examOrderLin,
     ...examOrderHum,
@@ -1363,12 +1364,23 @@ function renderExamSummary(){
       const td=document.createElement('td');
       const d=data[key];
       td.textContent=d && d.t ? `${d.c}/${d.a} de ${d.t}` : '-';
+      if(d){ totalC+=d.c; totalA+=d.a; }
       tr.appendChild(td);
     });
     tbody.appendChild(tr);
   });
   table.appendChild(tbody);
   container.appendChild(table);
+  const pct = totalA ? (totalC/totalA*100) : 0;
+  const perfColor = totalA===0 ? 'var(--c-neutral)'
+    : pct>=90 ? 'var(--c-blue)'
+    : pct>=80 ? 'var(--c-green)'
+    : pct>=60 ? 'var(--c-orange)'
+    : 'var(--c-red)';
+  const totalDiv=document.createElement('div');
+  totalDiv.className='exam-summary-total';
+  totalDiv.innerHTML=`${totalC}/${totalA} (<span style="color:${perfColor}">${pct.toFixed(1)}%</span>)`;
+  container.appendChild(totalDiv);
   app.appendChild(container);
 }
 /* ---------------- LISTA DE ASSUNTOS ---------------- */

--- a/styles.css
+++ b/styles.css
@@ -814,6 +814,11 @@ button:hover { filter: brightness(1.2); }
 .exam-summary-exam.exam-somos      { background: var(--c-exam-somos); }
 .exam-summary-exam.exam-evolucional{ background: var(--c-exam-evolucional); }
 
+.exam-summary-total {
+  margin-top: 8px;
+  text-align: center;
+}
+
 /* Items */
 .trail-item {
   display: flex;


### PR DESCRIPTION
## Summary
- Remove unnecessary "Desempenho por Simulado" heading and "Banca" column label from exam summary
- Display overall performance totals with color-coded percentage beneath the exam table
- Style the overall totals section for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc327ab7c8321ac59f546eef3bb0a