### PR TITLE
Show exam area in Provas e Simulados header

### DIFF
--- a/main.js
+++ b/main.js
@@ -1443,7 +1443,9 @@ function showExam(exam){
   currentExam=exam;
   leaveHome();
   toggleSettingsVisibility(false);
-  updateHeader(true, exam);
+  const areaTitles={lin:'Linguagens',hum:'Humanas',nat:'Natureza',mat:'Matemática'};
+  const area=areaTitles[currentExamMode]||'';
+  updateHeader(true, area ? `${exam} - ${area}` : exam);
   document.getElementById('headerStats').style.visibility='visible';
   clear();
   window.scrollTo(0,0);


### PR DESCRIPTION
## Summary
- Display the selected exam area alongside the exam name in the header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9451e33483218981f0b0f122c4c6