### PR TITLE
feat: personalize D1 colors and order questions

### DIFF
--- a/main.js
+++ b/main.js
@@ -208,20 +208,20 @@ const discClasses = {
   Química:    "quimica",
   Física:     "fisica",
   Matemática: "matematica",
-  'Linguagens': "d1",
-  'Geografia e Sociologia': "d1",
-  'História e Filosofia': "d1",
-  'Redação': "d1",
+  'Linguagens': "linguagens",
+  'Geografia e Sociologia': "geografia-sociologia",
+  'História e Filosofia': "historia-filosofia",
+  'Redação': "redacao",
 };
 const discColors = {
   Biologia: "var(--c-bio)",
   Química:  "var(--c-qui)",
   Física:   "var(--c-fis)",
   Matemática: "var(--c-mat)",
-  'Linguagens': "var(--c-d1)",
-  'Geografia e Sociologia': "var(--c-d1)",
-  'História e Filosofia': "var(--c-d1)",
-  'Redação': "var(--c-d1)"
+  'Linguagens': "var(--c-lin)",
+  'Geografia e Sociologia': "var(--c-geo-soc)",
+  'História e Filosofia': "var(--c-his-fil)",
+  'Redação': "var(--c-reda)",
 };
 
 // Valor especial usado para representar a disciplina inteira
@@ -1697,7 +1697,22 @@ function showQuestions(disc, sub, fromStar = false, fromTrailSub = false) {
   refreshStats();
 
   /* Renderiza cada questão */
-  questoesData[disc][sub].forEach((q, idx) => {
+  const qs = questoesData[disc][sub];
+  if (['Linguagens', 'História e Filosofia', 'Geografia e Sociologia'].includes(disc)) {
+    qs.sort((a, b) => {
+      const parse = q => {
+        const m = q.label.match(/^ENEM-(\d{4})-(REG|PPL|DIG)/);
+        if (!m) return [Infinity, Infinity];
+        return [parseInt(m[1], 10), {REG:0, PPL:1, DIG:2}[m[2]]];
+      };
+      const [yearA, modeA] = parse(a);
+      const [yearB, modeB] = parse(b);
+      if (yearA !== yearB) return yearA - yearB;
+      if (modeA !== modeB) return modeA - modeB;
+      return a.label.localeCompare(b.label);
+    });
+  }
+  qs.forEach((q, idx) => {
     const row = app.appendChild(Object.assign(
       document.createElement("div"), { className:"question-row" }));
 

--- a/styles.css
+++ b/styles.css
@@ -30,7 +30,10 @@
   --c-qui:  #0093D6;
   --c-fis:  #904992;
   --c-mat:  #F5821F;
-  --c-d1:   #CCA400;
+  --c-lin:  #0053B3;
+  --c-geo-soc: #007A00;
+  --c-his-fil: #FFD700;
+  --c-reda:  #00B7EB;
 }
 
 /* =====================================================================================
@@ -223,11 +226,14 @@ button:hover { filter: brightness(1.2); }
   justify-content: center;     /* já centraliza horizontalmente também */
   white-space: nowrap;
 }
-.disc-btn.biologia   { background: var(--c-bio); }
-.disc-btn.quimica    { background: var(--c-qui); }
-.disc-btn.fisica     { background: var(--c-fis); }
-.disc-btn.matematica { background: var(--c-mat); }
-.disc-btn.d1         { background: var(--c-d1); color:#fff; }
+.disc-btn.biologia             { background: var(--c-bio); }
+.disc-btn.quimica              { background: var(--c-qui); }
+.disc-btn.fisica               { background: var(--c-fis); }
+.disc-btn.matematica           { background: var(--c-mat); }
+.disc-btn.linguagens           { background: var(--c-lin); }
+.disc-btn.geografia-sociologia { background: var(--c-geo-soc); }
+.disc-btn.historia-filosofia   { background: var(--c-his-fil); }
+.disc-btn.redacao              { background: var(--c-reda); }
 
 /* =====================================================================================
    ESTRELAS DE PROGRESSO
@@ -876,11 +882,14 @@ button:hover { filter: brightness(1.2); }
 }
 
 /* Subject variants */
-.trail-subject.biologia   { background: var(--c-bio); }
-.trail-subject.quimica    { background: var(--c-qui); }
-.trail-subject.fisica     { background: var(--c-fis); }
-.trail-subject.matematica { background: var(--c-mat); }
-.trail-subject.d1         { background: var(--c-d1); }
+.trail-subject.biologia             { background: var(--c-bio); }
+.trail-subject.quimica              { background: var(--c-qui); }
+.trail-subject.fisica               { background: var(--c-fis); }
+.trail-subject.matematica           { background: var(--c-mat); }
+.trail-subject.linguagens           { background: var(--c-lin); }
+.trail-subject.geografia-sociologia { background: var(--c-geo-soc); }
+.trail-subject.historia-filosofia   { background: var(--c-his-fil); }
+.trail-subject.redacao              { background: var(--c-reda); }
 /* Exams */
 .trail-subject.exam-enem      { background: var(--c-exam-enem); }
 .trail-subject.exam-sas       { background: var(--c-exam-sas); }


### PR DESCRIPTION
## Summary
- Use unique background colors for D1 disciplines
- Sort D1 questions chronologically and prioritize REG before PPL before DIG

## Testing
- `node --check main.js`
- `node --check dataD1.js`


------
https://chatgpt.com/codex/tasks/task_e_68a611b675848321bde39e30601835cc