### PR TITLE
Ordena simulados do ENEM por ano e tipo

### DIFF
--- a/main.js
+++ b/main.js
@@ -393,32 +393,34 @@ function buildExamMap(list, mode='nat'){
       return na-nb;
     });
   }
-  if(mode === 'lin' || mode === 'hum'){
-    const typePriority = { REG:1, PPL:2, DIG:3 };
-    order.sort((a,b)=>{
-      const pa=a.split('-');
-      const pb=b.split('-');
-      const bancaA=pa[0].toLowerCase();
-      const bancaB=pb[0].toLowerCase();
-      if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
-      const yearA=parseInt(pa[1],10);
-      const yearB=parseInt(pb[1],10);
-      if(yearA!==yearB) return yearA-yearB;
-      if(bancaA==='enem'){
-        const ta=pa[2]||'';
-        const tb=pb[2]||'';
-        const va=typePriority[ta]||99;
-        const vb=typePriority[tb]||99;
-        if(va!==vb) return va-vb;
-      }
-      const restA=pa.slice(2).join('-');
-      const restB=pb.slice(2).join('-');
-      const na=parseInt(restA,10);
-      const nb=parseInt(restB,10);
-      if(!isNaN(na) && !isNaN(nb)) return na-nb;
-      return restA.localeCompare(restB);
-    });
-  }
+  const typePriority = { REG:1, PPL:2, DIG:3 };
+  order.sort((a,b)=>{
+    const pa=a.split('-');
+    const pb=b.split('-');
+    const bancaA=pa[0].toLowerCase();
+    const bancaB=pb[0].toLowerCase();
+    if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
+    const yearA=parseInt(pa[1],10);
+    const yearB=parseInt(pb[1],10);
+    if(yearA!==yearB){
+      if(isNaN(yearA)) return 1;
+      if(isNaN(yearB)) return -1;
+      return yearA-yearB;
+    }
+    if(bancaA==='enem'){
+      const ta=pa[2]||'';
+      const tb=pb[2]||'';
+      const va=typePriority[ta]||99;
+      const vb=typePriority[tb]||99;
+      if(va!==vb) return va-vb;
+    }
+    const restA=pa.slice(2).join('-');
+    const restB=pb.slice(2).join('-');
+    const na=parseInt(restA,10);
+    const nb=parseInt(restB,10);
+    if(!isNaN(na) && !isNaN(nb)) return na-nb;
+    return restA.localeCompare(restB);
+  });
   return { map: exams, order };
 }
 


### PR DESCRIPTION
## Summary
- ordena lista de simulados do ENEM do mais antigo para o mais recente
- em anos iguais, prioriza REG, depois PPL e por último DIG

## Testing
- `node -e 'const typePriority={REG:1,PPL:2,DIG:3}; const arr=["ENEM-2022-REG","ENEM-2023-PPL","ENEM-2023-DIG","ENEM-2023-REG","ENEM-2022-DIG","ENEM-2022-PPL"]; arr.sort((a,b)=>{const pa=a.split("-");const pb=b.split("-");const bancaA=pa[0].toLowerCase();const bancaB=pb[0].toLowerCase();if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);const yearA=parseInt(pa[1],10);const yearB=parseInt(pb[1],10);if(yearA!==yearB){if(isNaN(yearA)) return 1;if(isNaN(yearB)) return -1;return yearA-yearB;}if(bancaA==="enem"){const ta=pa[2]||"";const tb=pb[2]||"";const va=typePriority[ta]||99;const vb=typePriority[tb]||99;if(va!==vb) return va-vb;}const restA=pa.slice(2).join("-");const restB=pb.slice(2).join("-");const na=parseInt(restA,10);const nb=parseInt(restB,10);if(!isNaN(na) && !isNaN(nb)) return na-nb;return restA.localeCompare(restB);}); console.log(arr.join(","));'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6281d4bec8321b5b20b79d948b0d9