### PR TITLE
Order ENEM simulados chronologically

### DIFF
--- a/main.js
+++ b/main.js
@@ -419,6 +419,26 @@ function buildExamMap(list, mode='nat'){
       return restA.localeCompare(restB);
     });
   }
+  // Reordenar simulados do ENEM: mais antigos primeiro e, no mesmo ano,
+  // na ordem REG → PPL → DIG. Os demais simulados mantêm a ordem original.
+  const enemPriority = { REG:1, PPL:2, DIG:3 };
+  const enemExams = order.filter(name => name.startsWith('ENEM-'));
+  enemExams.sort((a,b) => {
+    const pa = a.split('-');
+    const pb = b.split('-');
+    const yearA = parseInt(pa[1], 10);
+    const yearB = parseInt(pb[1], 10);
+    if (yearA !== yearB) return yearA - yearB;
+    const ta = pa[2] || '';
+    const tb = pb[2] || '';
+    const va = enemPriority[ta] || 99;
+    const vb = enemPriority[tb] || 99;
+    if (va !== vb) return va - vb;
+    return 0;
+  });
+  const otherExams = order.filter(name => !name.startsWith('ENEM-'));
+  order.length = 0;
+  order.push(...enemExams, ...otherExams);
   return { map: exams, order };
 }
 


### PR DESCRIPTION
## Summary
- ensure ENEM mock exams show from oldest to newest in Provas e Simulados
- prioritize REG before PPL and DIG for same year while preserving other exam order

## Testing
- `node - <<'NODE'
function sortOrder(order){
 const enemPriority={REG:1,PPL:2,DIG:3};
 const enem=order.filter(n=>n.startsWith('ENEM-'));
 enem.sort((a,b)=>{
   const pa=a.split('-');
   const pb=b.split('-');
   const yearA=parseInt(pa[1],10);const yearB=parseInt(pb[1],10);
   if(yearA!==yearB) return yearA-yearB;
   const va=enemPriority[pa[2]||'']||99;
   const vb=enemPriority[pb[2]||'']||99;
   if(va!==vb) return va-vb;
   return 0;
 });
 const others=order.filter(n=>!n.startsWith('ENEM-'));
 return [...enem,...others];
}
console.log(sortOrder(['ENEM-2024-PPL','ENEM-2018-PPL','ENEM-2018-REG','SAS-2020','ENEM-2024-REG','ENEM-2024-DIG']));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a632c6a4e48321a1147f937e56b2a8