### PR TITLE
Fix exam ordering in Provas e Simulados

### DIFF
--- a/main.js
+++ b/main.js
@@ -363,11 +363,22 @@ function buildBancoQuestoes(listaFlat) {
 
 function compareExamNames(a,b){
   const typePriority = { REG:1, PPL:2, DIG:3 };
+  const bankPriority = {
+    enem:1,
+    sas:2,
+    bernoulli:3,
+    poliedro:4,
+    somos:5,
+    evolucional:6
+  };
   const pa=a.split('-');
   const pb=b.split('-');
   const bancaA=pa[0].toLowerCase();
   const bancaB=pb[0].toLowerCase();
-  if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
+  const bankOrderA=bankPriority[bancaA] || 999;
+  const bankOrderB=bankPriority[bancaB] || 999;
+  if(bankOrderA !== bankOrderB) return bankOrderA - bankOrderB;
+  if(bankOrderA === 999 && bancaA !== bancaB) return bancaA.localeCompare(bancaB);
   const yearA=parseInt(pa[1],10);
   const yearB=parseInt(pb[1],10);
   if(yearA!==yearB) return yearA-yearB;

--- a/main.js
+++ b/main.js
@@ -361,6 +361,31 @@ function buildBancoQuestoes(listaFlat) {
   return banco;
 }
 
+function compareExamNames(a,b){
+  const typePriority = { REG:1, PPL:2, DIG:3 };
+  const pa=a.split('-');
+  const pb=b.split('-');
+  const bancaA=pa[0].toLowerCase();
+  const bancaB=pb[0].toLowerCase();
+  if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
+  const yearA=parseInt(pa[1],10);
+  const yearB=parseInt(pb[1],10);
+  if(yearA!==yearB) return yearA-yearB;
+  if(bancaA==='enem'){
+    const ta=pa[2]||'';
+    const tb=pb[2]||'';
+    const va=typePriority[ta]||99;
+    const vb=typePriority[tb]||99;
+    if(va!==vb) return va-vb;
+  }
+  const restA=pa.slice(2).join('-');
+  const restB=pb.slice(2).join('-');
+  const na=parseInt(restA,10);
+  const nb=parseInt(restB,10);
+  if(!isNaN(na) && !isNaN(nb)) return na-nb;
+  return restA.localeCompare(restB);
+}
+
 function buildExamMap(list, mode='nat'){
   const exams = {};
   const order = [];
@@ -393,32 +418,7 @@ function buildExamMap(list, mode='nat'){
       return na-nb;
     });
   }
-  if(mode === 'lin' || mode === 'hum'){
-    const typePriority = { REG:1, PPL:2, DIG:3 };
-    order.sort((a,b)=>{
-      const pa=a.split('-');
-      const pb=b.split('-');
-      const bancaA=pa[0].toLowerCase();
-      const bancaB=pb[0].toLowerCase();
-      if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
-      const yearA=parseInt(pa[1],10);
-      const yearB=parseInt(pb[1],10);
-      if(yearA!==yearB) return yearA-yearB;
-      if(bancaA==='enem'){
-        const ta=pa[2]||'';
-        const tb=pb[2]||'';
-        const va=typePriority[ta]||99;
-        const vb=typePriority[tb]||99;
-        if(va!==vb) return va-vb;
-      }
-      const restA=pa.slice(2).join('-');
-      const restB=pb.slice(2).join('-');
-      const na=parseInt(restA,10);
-      const nb=parseInt(restB,10);
-      if(!isNaN(na) && !isNaN(nb)) return na-nb;
-      return restA.localeCompare(restB);
-    });
-  }
+  order.sort(compareExamNames);
   return { map: exams, order };
 }
 
@@ -1340,7 +1340,7 @@ function renderExamSummary(){
     ...examOrderHum,
     ...examOrderNat,
     ...examOrderMat
-  ])];
+  ])].sort(compareExamNames);
   order.forEach(exam=>{
     const data=exams[exam];
     if(!data) return;


### PR DESCRIPTION
## Summary
- Ensure exam listings sort by bank, year, and type
- Apply consistent ordering across areas and summary table

## Testing
- `node <<'NODE'
const fs=require('fs');
global.window={};
eval(fs.readFileSync('data.js','utf8'));
eval(fs.readFileSync('dataD1.js','utf8'));
const DISCIPLINES_BY_MODE={lin:['Linguagens'],hum:['Geografia e Sociologia','História e Filosofia'],nat:['Biologia','Química','Física'],mat:['Matemática']};
function compareExamNames(a,b){const typePriority={REG:1,PPL:2,DIG:3};const pa=a.split('-');const pb=b.split('-');const bancaA=pa[0].toLowerCase();const bancaB=pb[0].toLowerCase();if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);const yearA=parseInt(pa[1],10);const yearB=parseInt(pb[1],10);if(yearA!==yearB) return yearA-yearB;if(bancaA==='enem'){const ta=pa[2]||'';const tb=pb[2]||'';const va=typePriority[ta]||99;const vb=typePriority[tb]||99;if(va!==vb) return va-vb;}const restA=pa.slice(2).join('-');const restB=pb.slice(2).join('-');const na=parseInt(restA,10);const nb=parseInt(restB,10);if(!isNaN(na)&&!isNaN(nb)) return na-nb;return restA.localeCompare(restB);}
function buildExamMap(list,mode){const exams={};const order=[];const allowed=new Set(DISCIPLINES_BY_MODE[mode]||[]);list.forEach(item=>{const m=item.label.match(/^(.*)-Q-(\d+)/);if(!m||(allowed.size&&!allowed.has(item.Disciplina))) return;const exam=m[1];if(!exams[exam]){exams[exam]=[];order.push(exam);}exams[exam].push({disc:item.Disciplina,sub:item.Assunto,q:item});});order.sort(compareExamNames);return {order};}
const all=[buildExamMap([...window.listaQuestoes,...window.listaQuestoesD1],'lin').order,buildExamMap([...window.listaQuestoes,...window.listaQuestoesD1],'hum').order,buildExamMap([...window.listaQuestoes,...window.listaQuestoesD1],'nat').order,buildExamMap([...window.listaQuestoes,...window.listaQuestoesD1],'mat').order];
const order=[...new Set(all.flat())].sort(compareExamNames);
console.log(order.filter(e=>e.startsWith('ENEM-2021')||e.startsWith('ENEM-2022')||e.startsWith('ENEM-2023')||e.startsWith('ENEM-2024')).join('\n'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a6356242348321be8d2a935d858ee3