### PR TITLE
Remove linear/human sorting

### DIFF
--- a/main.js
+++ b/main.js
@@ -393,32 +393,6 @@ function buildExamMap(list, mode='nat'){
       return na-nb;
     });
   }
-  if(mode === 'lin' || mode === 'hum'){
-    const typePriority = { REG:1, PPL:2, DIG:3 };
-    order.sort((a,b)=>{
-      const pa=a.split('-');
-      const pb=b.split('-');
-      const bancaA=pa[0].toLowerCase();
-      const bancaB=pb[0].toLowerCase();
-      if(bancaA!==bancaB) return bancaA.localeCompare(bancaB);
-      const yearA=parseInt(pa[1],10);
-      const yearB=parseInt(pb[1],10);
-      if(yearA!==yearB) return yearA-yearB;
-      if(bancaA==='enem'){
-        const ta=pa[2]||'';
-        const tb=pb[2]||'';
-        const va=typePriority[ta]||99;
-        const vb=typePriority[tb]||99;
-        if(va!==vb) return va-vb;
-      }
-      const restA=pa.slice(2).join('-');
-      const restB=pb.slice(2).join('-');
-      const na=parseInt(restA,10);
-      const nb=parseInt(restB,10);
-      if(!isNaN(na) && !isNaN(nb)) return na-nb;
-      return restA.localeCompare(restB);
-    });
-  }
   return { map: exams, order };
 }
 


### PR DESCRIPTION
## Summary
- remove special sorting branch for linear/human exam modes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a63e40a2508321853d388aec6d46ba