### PR TITLE
fix: order exam summary by nature

### DIFF
--- a/main.js
+++ b/main.js
@@ -1310,9 +1310,9 @@ function renderExamSummary(){
   const tbody=document.createElement('tbody');
   const totals={Lin:{c:0,a:0},Hum:{c:0,a:0},Nat:{c:0,a:0},Mat:{c:0,a:0}};
   const order=[...new Set([
+    ...examOrderNat,
     ...examOrderLin,
     ...examOrderHum,
-    ...examOrderNat,
     ...examOrderMat
   ])];
   order.forEach(exam=>{


### PR DESCRIPTION
## Summary
- ensure Provas e Simulados summary rows follow Natureza exam order

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a649e072ec8321b72f9efaa7540c8d