### PR TITLE
Fix Evolucional background color in strategic trail

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -896,6 +896,7 @@ button:hover { filter: brightness(1.2); }
 .trail-subject.exam-bernoulli { background: var(--c-exam-bernoulli); }
 .trail-subject.exam-poliedro  { background: var(--c-exam-poliedro); }
 .trail-subject.exam-somos     { background: var(--c-exam-somos); }
+.trail-subject.exam-evolucional{ background: var(--c-exam-evolucional); }
 
 .trail-comment {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- add CSS rule for Evolucional exam buttons in the strategic trail

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70318f07c8321b42f7c99f838bb8d