### PR TITLE
Add arrow shorthand auto-conversion

### DIFF
--- a/main.js
+++ b/main.js
@@ -528,14 +528,36 @@ function isImageUrl(url) {
           /^https:\/\/firebasestorage\.googleapis\.com\/v0\/b\/[^/]+\/o\/.+\?alt=media.*$/i.test(url));
 }
 
-// Substitui qualquer ocorrência de "-->" por uma seta "→" dentro de um elemento
-function replaceArrows(div){
-  const walker=document.createTreeWalker(div,NodeFilter.SHOW_TEXT,null);
-  let node;
-  while((node=walker.nextNode())){
-    if(node.textContent.includes('-->')){
-      node.textContent=node.textContent.replace(/-->/g,'→');
+// Substitui a notação "-->" por "→" mantendo o cursor no lugar.
+// Quando `global` é true, faz varredura completa (usado ao carregar/pastar texto).
+function replaceArrows(div, global = false){
+  if(global){
+    const walker=document.createTreeWalker(div,NodeFilter.SHOW_TEXT,null);
+    let node;
+    while((node=walker.nextNode())){
+      if(node.textContent.includes('-->')){
+        node.textContent=node.textContent.replace(/-->/g,'→');
+      }
     }
+    return;
+  }
+
+  const sel=window.getSelection();
+  if(!sel.rangeCount || !div.contains(sel.anchorNode)) return;
+  const range=sel.getRangeAt(0);
+  const node=range.startContainer;
+  if(node.nodeType!==Node.TEXT_NODE) return;
+
+  const text=node.textContent;
+  const pos=range.startOffset;
+  const before=text.slice(0,pos);
+  if(before.endsWith('-->')){
+    node.textContent = before.slice(0,-3)+'→'+text.slice(pos);
+    const newPos=pos-2; // remove 3 chars, add 1
+    range.setStart(node,newPos);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
   }
 }
 
@@ -1506,7 +1528,8 @@ function showExam(exam){
     editDiv.dataset.ph='';
     editDiv.addEventListener('click',function(e){if(e.button!==0)return;const anchor=e.target.closest('a');if(anchor){e.preventDefault();if(isImageUrl(anchor.href))openImage(anchor.href);else window.open(anchor.href,'_blank','noopener');return;}if(!editDiv.classList.contains('expanded')){editDiv.focus();}});
     editDiv.innerHTML=localStorage.getItem(cKey)||'';
-    editDiv.addEventListener('paste',e=>{e.preventDefault();const plain=e.clipboardData.getData('text/plain');const sel=window.getSelection();if(!sel.rangeCount)return;const range=sel.getRangeAt(0);range.deleteContents();range.insertNode(document.createTextNode(plain));range.collapse(false);sel.removeAllRanges();sel.addRange(range);});
+    replaceArrows(editDiv,true);
+    editDiv.addEventListener('paste',e=>{e.preventDefault();const plain=e.clipboardData.getData('text/plain');const sel=window.getSelection();if(!sel.rangeCount)return;const range=sel.getRangeAt(0);range.deleteContents();range.insertNode(document.createTextNode(plain));range.collapse(false);sel.removeAllRanges();sel.addRange(range);replaceArrows(editDiv,true);});
     editDiv.addEventListener('input',()=>{if(editDiv.classList.contains('expanded')){fitHeight(editDiv);}});
     editDiv.addEventListener('focus',()=>{editDiv.classList.add('expanded');editDiv.style.whiteSpace='pre-wrap';editDiv.style.overflowY='auto';fitHeight(editDiv);});
     editDiv.addEventListener('blur',()=>{if(editDiv.textContent.trim()===''){editDiv.innerHTML='';localStorage.removeItem(cKey);}editDiv.classList.remove('expanded');editDiv.style.maxHeight='38px';editDiv.style.whiteSpace='nowrap';editDiv.style.textOverflow='ellipsis';editDiv.style.overflow='hidden';editDiv.scrollTop=0;atualizaIndicadorOverflow(editDiv);});
@@ -2108,6 +2131,7 @@ function showMicroSim(entry) {
       }
     });
     editDiv.innerHTML=localStorage.getItem(cKey)||'';
+    replaceArrows(editDiv,true);
     editDiv.addEventListener('paste',e=>{
       e.preventDefault();
       const plain=e.clipboardData.getData('text/plain');
@@ -2117,6 +2141,7 @@ function showMicroSim(entry) {
       range.deleteContents();
       range.insertNode(document.createTextNode(plain));
       range.collapse(false); sel.removeAllRanges(); sel.addRange(range);
+      replaceArrows(editDiv,true);
     });
     editDiv.addEventListener('input',()=>{ if(editDiv.classList.contains('expanded')) fitHeight(editDiv); });
     editDiv.addEventListener('focus',()=>{ editDiv.classList.add('expanded'); editDiv.style.whiteSpace='pre-wrap'; editDiv.style.overflowY='auto'; fitHeight(editDiv); });


### PR DESCRIPTION
## Summary
- Convert `-->` into `→` within comment editors via a new `replaceArrows` helper
- Normalize the same shorthand in Trilha Estratégica comments when adding or editing notes

## Testing
- `node --check main.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72e35d9248321951e169b79c11a60