### PR TITLE
Add cache refresh control to settings menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
       <button id="toggleD1Btn">Exibir - D1</button>
       <button id="importBtn">Importar</button>
       <button id="exportBtn">Exportar</button>
+      <button id="clearCacheBtn" title="Força o navegador a baixar os arquivos mais recentes sem apagar seu progresso.">Limpar Cache</button>
     </div>
     <div class="header-top">
       <span id="headerTitle">Título Dinâmico

--- a/main.js
+++ b/main.js
@@ -266,6 +266,7 @@ const exportBtn     = document.getElementById("exportBtn");
 const importBtn     = document.getElementById("importBtn");
 const trilhaBtn     = document.getElementById("trilhaBtn");
 const examsBtn     = document.getElementById("examsBtn");
+const clearCacheBtn = document.getElementById("clearCacheBtn");
 const pickerModal   = document.getElementById("subjectPickerModal");
 const pickerDisc    = document.getElementById("pickerDisc");
 const pickerSub     = document.getElementById("pickerSub");
@@ -885,6 +886,55 @@ importBtn.onclick = () => {
   settingsMenu.style.display = "none";
   importFile.click();
 };
+
+if (clearCacheBtn) {
+  clearCacheBtn.onclick = async () => {
+    settingsMenu.style.display = "none";
+    const confirmed = confirm(
+      "Deseja limpar o cache?\nIsso faz o navegador baixar a versão mais recente sem apagar seu progresso."
+    );
+    if (!confirmed) return;
+
+    clearCacheBtn.disabled = true;
+    clearCacheBtn.textContent = "Limpando...";
+
+    try {
+      if ("caches" in window) {
+        const cacheNames = await caches.keys();
+        await Promise.all(cacheNames.map(name => caches.delete(name).catch(() => {})));
+      }
+
+      const resources = new Set();
+      const addLocalResource = url => {
+        if (!url) return;
+        const absolute = new URL(url, window.location.href);
+        if (absolute.origin === window.location.origin) {
+          resources.add(absolute.href);
+        }
+      };
+
+      addLocalResource(window.location.href);
+      document
+        .querySelectorAll('link[rel="stylesheet"]')
+        .forEach(link => addLocalResource(link.getAttribute('href')));
+      document
+        .querySelectorAll('script[src]')
+        .forEach(script => addLocalResource(script.getAttribute('src')));
+
+      await Promise.all(
+        [...resources].map(url =>
+          fetch(url, { cache: 'reload' }).catch(err =>
+            console.warn('Falha ao atualizar recurso', url, err)
+          )
+        )
+      );
+    } catch (err) {
+      console.error('Erro ao limpar cache', err);
+    }
+
+    window.location.reload();
+  };
+}
 
 /* ---------------- TRILHA ESTRATÉGICA ---------------- */
 trilhaBtn.onclick = () => {


### PR DESCRIPTION
## Summary
- add a "Limpar Cache" entry to the settings menu so users can manually refresh cached files when the hosted version looks outdated
- clear Cache Storage, revalidate local assets and reload the page without touching saved progress when the new control is used

## Testing
- no tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c9cbc807dc832185577405be2a9eda