### PR TITLE
Fix PDF viewer scroll behavior on mobile devices

### DIFF
--- a/main.js
+++ b/main.js
@@ -3899,6 +3899,22 @@ editDiv.addEventListener('click', function(e) {
 /* ================================================================
    6. VISUALIZAÇÃO DE PDF (PDF.js)
    ============================================================== */
+function isLikelyMobilePhone() {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const platform = navigator.platform || '';
+  const maxTouchPoints = Number(navigator.maxTouchPoints || 0);
+  const isIpad = /\b(iPad)\b/i.test(ua) || (platform === 'MacIntel' && maxTouchPoints > 1);
+  if (isIpad) return false;
+  if (/\bTablet\b/i.test(ua)) return false;
+  if (/\bAndroid\b/i.test(ua) && !/\bMobile\b/i.test(ua)) return false;
+  return /\b(iPhone|iPod)\b/i.test(ua) || /\bMobile\b/i.test(ua);
+}
+
+function shouldForcePdfPenMode() {
+  return !isLikelyMobilePhone();
+}
+
 function clearPdfViewerContent() {
   cancelPdfAutosave();
   pdfDirtyLayers.clear();
@@ -5190,12 +5206,16 @@ async function openPdf(pdfName, pages, quality = PDF_RENDER_QUALITY, zoom = null
   const sortedPages = pagesToRender.slice().sort((a, b) => a - b);
   const desiredPage = sortedPages.length ? sortedPages[0] : null;
   const wasHidden = pdfContainer.style.display !== "flex";
+  const forcePenMode = shouldForcePdfPenMode();
   cleanupStalePdfDrawings();
   ensurePdfPersistenceHandlers();
   pdfContainer.style.display = "flex";
   setBodyScrollLocked(true);
+  setPdfIpadMode(true, { forcePen: forcePenMode && wasHidden });
   if (wasHidden) {
-    setPdfIpadMode(true, { forcePen: true });
+    if (!forcePenMode) {
+      setPdfDrawingTool('hand');
+    }
     pdfContainer.scrollTop = 0;
     setPdfPageMenuOpen(false);
   } else {

--- a/styles.css
+++ b/styles.css
@@ -502,6 +502,8 @@ button:hover { filter: brightness(1.2); }
   flex-direction: column;
   align-items: center;
   overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   z-index: 1000;
   padding: 0 16px 32px;
   -webkit-user-select: none;


### PR DESCRIPTION
## Summary
- detect likely mobile phones and avoid forcing pen mode when opening the PDF viewer so scrolling stays in hand mode
- add overscroll containment and iOS momentum scrolling styles to stabilize the PDF modal on touch devices
- expose helpers to keep stylus mode for tablets while improving the default experience on phones

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ffdf95ac832188f98fd1e72d851c)