### PR TITLE
Atualiza datas do ENEM para 08/11/2026 (D1) e 15/11/2026 (D2)

### DIFF
--- a/main.js
+++ b/main.js
@@ -292,9 +292,9 @@ let postReviewModeRestore = null;
 let d1Enabled = JSON.parse(localStorage.getItem('d1Enabled') || 'false');
 
 // Data prevista do exame no fuso de Brasília (-03)
-const EXAM_DATE = new Date('2025-11-09T00:00:00-03:00');
+const EXAM_DATE = new Date('2026-11-08T00:00:00-03:00');
 // Segunda aplicação do ENEM (D2) e data final exibida na trilha
-const SECOND_EXAM_DATE = new Date('2025-11-16T00:00:00-03:00');
+const SECOND_EXAM_DATE = new Date('2026-11-15T00:00:00-03:00');
 const TRAIL_END_DATE = SECOND_EXAM_DATE;
 
 /* ================================================================
@@ -6085,7 +6085,7 @@ window.addEventListener('focus', resumePomodoroIfNeeded);
 (() => {
 
   /* ---------- Configurações ---------- */
-  const EXAM_DATE = new Date('2025-11-09T00:00:00-03:00');  // 09/11/2025
+  const EXAM_DATE = new Date('2026-11-08T00:00:00-03:00');  // 08/11/2026
 
   /* ---------- Seletores ---------- */
   const xpModal      = document.getElementById('xpModal');


### PR DESCRIPTION
### Motivation
- Ajustar a data do exame usada pela Trilha Estratégica e pelo contador de dias para refletir a nova data do ENEM 2026.

### Description
- Substituídas as constantes `EXAM_DATE` e `SECOND_EXAM_DATE` em `main.js` para `2026-11-08T00:00:00-03:00` e `2026-11-15T00:00:00-03:00`, respectivamente, e atualizado o `TRAIL_END_DATE` para usar o D2.

### Testing
- Executado `node --check main.js` para verificação de sintaxe e passou com sucesso.
- Executado `git diff --check` para detecção de problemas de formatação/whitespace e passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4578be7acc832188fa1ad253d21ee5)