### PR TITLE
Ajusta menu de configurações: renomeia Revisão, oculta controles e adiciona Programador

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,16 +62,22 @@
     <div id="settingsMenu">
       <button id="trilhaBtn">Trilha Estratégica</button>
       <button id="examsBtn">Provas e Simulados</button>
-      <button id="natReviewBtn">Revisão</button>
-      <button id="reviewModeBtn">Pós-Revisão</button>
+      <button id="natReviewBtn">Revisão (Erradas)</button>
+      <button id="reviewModeBtn">Estatísticas Pós-Revisão</button>
       <button id="searchNotesBtn">Buscar anotações</button>
-      <button id="toggleD1Btn">Exibir - D1</button>
+      <button id="toggleD1Btn" class="settings-hidden-control">Exibir - D1</button>
       <button id="importBtn">Importar</button>
       <button id="exportBtn">Exportar</button>
-      <button id="importHandBtn">Handwriting - Importar</button>
-      <button id="exportHandBtn">Handwriting - Exportar</button>
-      <button id="clearManuscriptsBtn" title="Apaga todas as anotações feitas nos PDFs.">Limpar manuscritos</button>
-      <button id="clearCacheBtn" title="Força o navegador a baixar os arquivos mais recentes sem apagar seu progresso.">Limpar Cache</button>
+      <button id="importHandBtn" class="settings-hidden-control">Handwriting - Importar</button>
+      <button id="exportHandBtn" class="settings-hidden-control">Handwriting - Exportar</button>
+      <div class="settings-programmer-group">
+        <button id="programmerBtn" aria-expanded="false" aria-controls="programmerMenu">Programador</button>
+        <div id="programmerMenu" class="settings-submenu">
+          <button id="clearQuestionsBtn" title="Apaga dados de questões, comentários, revisão e demais progressos salvos.">Limpar Questões</button>
+          <button id="clearManuscriptsBtn" title="Apaga todas as anotações feitas nos PDFs.">Limpar Manuscritos</button>
+          <button id="clearCacheBtn" title="Força o navegador a baixar os arquivos mais recentes sem apagar seu progresso.">Limpar Cache</button>
+        </div>
+      </div>
     </div>
     <div class="header-top">
       <span id="headerTitle">Título Dinâmico

--- a/index.html
+++ b/index.html
@@ -71,11 +71,12 @@
       <button id="importHandBtn" class="settings-hidden-control">Handwriting - Importar</button>
       <button id="exportHandBtn" class="settings-hidden-control">Handwriting - Exportar</button>
       <div class="settings-programmer-group">
-        <button id="programmerBtn" aria-expanded="false" aria-controls="programmerMenu">Programador</button>
+        <button id="programmerBtn" aria-expanded="false" aria-controls="programmerMenu">Limpar</button>
         <div id="programmerMenu" class="settings-submenu">
-          <button id="clearQuestionsBtn" title="Apaga dados de questões, comentários, revisão e demais progressos salvos.">Limpar Questões</button>
-          <button id="clearManuscriptsBtn" title="Apaga todas as anotações feitas nos PDFs.">Limpar Manuscritos</button>
-          <button id="clearCacheBtn" title="Força o navegador a baixar os arquivos mais recentes sem apagar seu progresso.">Limpar Cache</button>
+          <button id="clearAllBtn" title="Apaga todos os dados locais e limpa o cache.">Tudo</button>
+          <button id="clearQuestionsBtn" title="Apaga dados de questões, comentários, revisão e demais progressos salvos.">Questões</button>
+          <button id="clearManuscriptsBtn" title="Apaga todas as anotações feitas nos PDFs.">Manuscritos</button>
+          <button id="clearCacheBtn" title="Força o navegador a baixar os arquivos mais recentes sem apagar seu progresso.">Cache</button>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       <button id="favReviewBtn">Revisão (Favoritas)</button>
       <button id="reviewModeBtn">Estatísticas Pós-Revisão</button>
       <button id="searchNotesBtn">Buscar anotações</button>
-      <button id="toggleD1Btn" class="settings-hidden-control">Exibir - D1</button>
+      <button id="toggleD1Btn">Exibir - D1</button>
       <button id="importBtn">Importar</button>
       <button id="exportBtn">Exportar</button>
       <button id="importHandBtn" class="settings-hidden-control">Handwriting - Importar</button>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
       <button id="trilhaBtn">Trilha Estratégica</button>
       <button id="examsBtn">Provas e Simulados</button>
       <button id="natReviewBtn">Revisão (Erradas)</button>
+      <button id="favReviewBtn">Revisão (Favoritas)</button>
       <button id="reviewModeBtn">Estatísticas Pós-Revisão</button>
       <button id="searchNotesBtn">Buscar anotações</button>
       <button id="toggleD1Btn" class="settings-hidden-control">Exibir - D1</button>

--- a/index.html
+++ b/index.html
@@ -62,13 +62,23 @@
     <div id="settingsMenu">
       <button id="trilhaBtn">Trilha Estratégica</button>
       <button id="examsBtn">Provas e Simulados</button>
-      <button id="natReviewBtn">Revisão (Erradas)</button>
-      <button id="favReviewBtn">Revisão (Favoritas)</button>
+      <div class="settings-programmer-group">
+        <button id="reviewMenuBtn" aria-expanded="false" aria-controls="reviewMenu">Revisão</button>
+        <div id="reviewMenu" class="settings-submenu">
+          <button id="natReviewBtn">Erradas</button>
+          <button id="favReviewBtn">Favoritas</button>
+        </div>
+      </div>
       <button id="reviewModeBtn">Estatísticas Pós-Revisão</button>
       <button id="searchNotesBtn">Buscar anotações</button>
       <button id="toggleD1Btn">Exibir - D1</button>
-      <button id="importBtn">Importar</button>
-      <button id="exportBtn">Exportar</button>
+      <div class="settings-programmer-group">
+        <button id="backupMenuBtn" aria-expanded="false" aria-controls="backupMenu">Backup</button>
+        <div id="backupMenu" class="settings-submenu">
+          <button id="importBtn">Importar</button>
+          <button id="exportBtn">Exportar</button>
+        </div>
+      </div>
       <button id="importHandBtn" class="settings-hidden-control">Handwriting - Importar</button>
       <button id="exportHandBtn" class="settings-hidden-control">Handwriting - Exportar</button>
       <div class="settings-programmer-group">

--- a/main.js
+++ b/main.js
@@ -516,20 +516,6 @@ function renderReviewSettingsMenu() {
   divider.className = 'review-menu-divider';
   reviewSettingsMenu.appendChild(divider);
 
-  const hiddenBtn = document.createElement('button');
-  hiddenBtn.className = 'review-menu-option review-menu-toggle';
-  hiddenBtn.type = 'button';
-  const showHidden = !!natReviewState.showHidden;
-  hiddenBtn.textContent = showHidden ? 'Ocultar' : 'Exibir Ocultas';
-  if (showHidden) hiddenBtn.classList.add('active');
-  hiddenBtn.addEventListener('click', () => {
-    setNatReviewState({ showHidden: !natReviewState.showHidden });
-    reviewSettingsMenu.style.display = 'none';
-    reviewSettingsBtn.setAttribute('aria-expanded', 'false');
-    showNatReview();
-  });
-  reviewSettingsMenu.appendChild(hiddenBtn);
-
   const pendingBtn = document.createElement('button');
   pendingBtn.className = 'review-menu-option review-menu-toggle';
   pendingBtn.type = 'button';
@@ -1129,7 +1115,7 @@ function clearQuestionDataFromLocalStorage() {
   const keysToRemove = [];
   for (let i = 0; i < localStorage.length; i += 1) {
     const key = localStorage.key(i);
-    if (!isHandwritingStorageKey(key)) {
+    if (!isHandwritingStorageKey(key) && !key.startsWith('summary_')) {
       keysToRemove.push(key);
     }
   }
@@ -1665,6 +1651,24 @@ if (typeof sessionStorage !== 'undefined') {
   }
 }
 /* ---------------- MENU PRINCIPAL ---------------- */
+function getDisciplineQuestionStats(disc) {
+  const subjects = questoesData[disc] || {};
+  let correct = 0;
+  let answered = 0;
+  let total = 0;
+
+  Object.entries(subjects).forEach(([sub, questions]) => {
+    questions.forEach((q) => {
+      total += 1;
+      const state = getEffectiveQuestionState(disc, sub, q.label);
+      if (state === 1 || state === 2) answered += 1;
+      if (state === 1) correct += 1;
+    });
+  });
+
+  return { correct, answered, total };
+}
+
 function showMenu () {
   examListOpen=false;
   currentExam=null;
@@ -1736,7 +1740,6 @@ function showMenu () {
     const btn = Object.assign(
       document.createElement("button"), {
         className: `disc-btn ${discClasses[disc]}`,
-        textContent: disc,
         onclick: () => {
           if(disc === 'Redação') {
             currentDisc = disc;
@@ -1747,6 +1750,15 @@ function showMenu () {
           }
         },
       });
+    btn.appendChild(Object.assign(
+      document.createElement('span'),
+      { className: 'disc-btn-label', textContent: disc }
+    ));
+    const { correct, answered, total } = getDisciplineQuestionStats(disc);
+    btn.appendChild(Object.assign(
+      document.createElement('span'),
+      { className: 'disc-btn-stats', textContent: `${correct}/${answered}[${total}]` }
+    ));
     if(disc === 'Geografia e Sociologia') btn.style.padding='0 4px';
     line.appendChild(btn);
 
@@ -2864,19 +2876,13 @@ function collectNatReviewItems(filter=null){
       const key = qKey(disc,sub,q.label);
       const state = getStoredQuestionState(disc, sub, q.label);
       const effectiveState = getEffectiveStateFromKey(key, state);
-      const hiddenKey = `${NAT_REVIEW_HIDDEN_PREFIX}${key}`;
-      const autoHiddenKey = `${NAT_REVIEW_AUTO_HIDDEN_PREFIX}${key}`;
       const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
-      const soonKey = `${NAT_REVIEW_SOON_PREFIX}${key}`;
-      const isHidden = localStorage.getItem(hiddenKey) === '1';
-      const isAutoHidden = localStorage.getItem(autoHiddenKey) === '1';
       const isFavorite = localStorage.getItem(favoriteKey) === '1';
-      const isSoon = localStorage.getItem(soonKey) === '1';
       if(effectiveState === 2){
-        combined.push({exam,mode,disc,sub,q,type:'wrong',hidden:isHidden,favorite:isFavorite,soon:isSoon,autoHidden:isAutoHidden});
+        combined.push({exam,mode,disc,sub,q,type:'wrong',favorite:isFavorite});
       }
       if(isEnem && effectiveState === 0){
-        combined.push({exam,mode,disc,sub,q,type:'pending',hidden:isHidden,favorite:isFavorite,soon:isSoon,autoHidden:isAutoHidden});
+        combined.push({exam,mode,disc,sub,q,type:'pending',favorite:isFavorite});
       }
     });
     visited.add(exam);
@@ -2929,8 +2935,7 @@ function countNatReviewItems(filter=null){
   const combined = collectNatReviewItems(effectiveFilter);
   const showPending = natReviewState.showPending;
   const filteredItems = combined.filter(item => showPending || item.type !== 'pending');
-  const visibleItems = filteredItems.filter(item => !item.hidden);
-  const snapshot = computeNatReviewSnapshot(visibleItems);
+  const snapshot = computeNatReviewSnapshot(filteredItems);
   return Math.max(snapshot.totalCount - snapshot.reviewedCount, 0);
 }
 /* ---------------- LISTA DE ASSUNTOS ---------------- */
@@ -3107,7 +3112,7 @@ function showNatReview(filter=null){
   if(filter){
     setNatReviewState(filter);
   }
-  const { mode: reviewMode = 'nat', disc, sub, showHidden, showPending } = natReviewState;
+  const { mode: reviewMode = 'nat', disc, sub, showPending } = natReviewState;
   const isAll = disc === REVIEW_ALL_DISC;
   const effectiveFilter = isAll
     ? { mode: reviewMode }
@@ -3162,11 +3167,7 @@ function showNatReview(filter=null){
       if (emptyMsg.isConnected) emptyMsg.remove();
     } else {
       let message = baseEmptyText;
-      const hiddenSnapshot = computeNatReviewSnapshot(itemsForView.filter(item => item.hidden && !item.favorite));
-      const visibleSnapshot = computeNatReviewSnapshot(itemsForView.filter(item => !item.hidden || item.favorite));
-      if (!showHidden && hiddenSnapshot.totalCount > 0 && visibleSnapshot.totalCount === 0) {
-        message = 'Todas as questões deste filtro estão ocultas. Use “Exibir Ocultas”.';
-      } else if (pendingFilteredOut) {
+      if (pendingFilteredOut) {
         message = 'Ative “Exibir Não Feitas” para ver as questões pendentes.';
       }
       emptyMsg.textContent = message;
@@ -3194,83 +3195,24 @@ function showNatReview(filter=null){
     };
     if (!qualifies()) return;
 
-    const hiddenKey = `${NAT_REVIEW_HIDDEN_PREFIX}${key}`;
-    const autoHiddenKey = `${NAT_REVIEW_AUTO_HIDDEN_PREFIX}${key}`;
     const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
-    const soonKey = `${NAT_REVIEW_SOON_PREFIX}${key}`;
 
-    let isHidden = !!item.hidden;
-    let autoHidden = localStorage.getItem(autoHiddenKey) === '1';
     let isFavorite = !!item.favorite;
-    let isSoon = !!item.soon;
 
     const reviewKey = `natReview_${key}`;
     let reviewState = +localStorage.getItem(reviewKey) || 0;
 
-    const syncWithReviewState = ({ deferAutoHide = false } = {}) => {
-      const shouldDefer = deferAutoHide || natReviewDeferredAutoHide.has(key);
-      if (reviewState === 1) {
-        if (isFavorite) {
-          natReviewDeferredAutoHide.delete(key);
-          if (isHidden) {
-            isHidden = false;
-            localStorage.removeItem(hiddenKey);
-          }
-          if (autoHidden) {
-            autoHidden = false;
-            localStorage.removeItem(autoHiddenKey);
-          }
-        } else {
-          if (!autoHidden) {
-            autoHidden = true;
-          }
-          localStorage.setItem(autoHiddenKey, '1');
-          if (shouldDefer) {
-            natReviewDeferredAutoHide.add(key);
-            if (isHidden) {
-              isHidden = false;
-              localStorage.removeItem(hiddenKey);
-            }
-          } else {
-            natReviewDeferredAutoHide.delete(key);
-            if (!isHidden) {
-              isHidden = true;
-            }
-            localStorage.setItem(hiddenKey, '1');
-          }
-        }
-      } else {
-        if (natReviewDeferredAutoHide.has(key)) {
-          natReviewDeferredAutoHide.delete(key);
-        }
-        if (autoHidden) {
-          autoHidden = false;
-          localStorage.removeItem(autoHiddenKey);
-          if (isHidden) {
-            isHidden = false;
-            localStorage.removeItem(hiddenKey);
-          }
-        }
-      }
-      item.hidden = isHidden;
-      item.autoHidden = autoHidden;
+    const syncWithReviewState = () => {
+      item.favorite = isFavorite;
     };
 
     syncWithReviewState();
 
-    if (!natReviewState.showHidden && isHidden && !isFavorite) {
-      return;
-    }
-
-    item.hidden = isHidden;
     item.favorite = isFavorite;
-    item.soon = isSoon;
 
     const row = document.createElement('div');
     row.className = 'question-row';
-    if (isHidden) row.classList.add('review-hidden');
     if (isFavorite) row.classList.add('review-favorite');
-    if (isSoon) row.classList.add('review-soon');
 
     const qBtn = document.createElement('button');
     qBtn.classList.add('btn', 'question-btn', 'two-line-btn', 'question-btn--with-menu');
@@ -3318,15 +3260,7 @@ function showNatReview(filter=null){
     const favoriteOption = document.createElement('button');
     favoriteOption.type = 'button';
     favoriteOption.className = 'question-action-option';
-    const soonOption = document.createElement('button');
-    soonOption.type = 'button';
-    soonOption.className = 'question-action-option';
-    const hideOption = document.createElement('button');
-    hideOption.type = 'button';
-    hideOption.className = 'question-action-option';
     actionMenu.appendChild(favoriteOption);
-    actionMenu.appendChild(soonOption);
-    actionMenu.appendChild(hideOption);
     row.appendChild(actionMenu);
 
     const controls = document.createElement('div');
@@ -3383,11 +3317,7 @@ function showNatReview(filter=null){
         localStorage.setItem(reviewKey, reviewState);
       }
       paintReview();
-      syncWithReviewState({ deferAutoHide: reviewState === 1 });
-      paintHide();
-      if (!natReviewState.showHidden && isHidden && !isFavorite) {
-        row.remove();
-      }
+      syncWithReviewState();
       ensureEmptyState();
       refreshStats();
     };
@@ -3395,28 +3325,14 @@ function showNatReview(filter=null){
     controls.appendChild(reviewBox);
 
     const updateMenuToggle = () => {
-      const hasState = isHidden || isFavorite || isSoon;
+      const hasState = isFavorite;
       menuToggle.classList.toggle('menu-active', hasState);
-    };
-
-    const paintHide = () => {
-      hideOption.textContent = isHidden ? 'Exibir' : 'Ocultar';
-      hideOption.classList.toggle('active', isHidden);
-      row.classList.toggle('review-hidden', isHidden);
-      updateMenuToggle();
     };
 
     const paintFavorite = () => {
       favoriteOption.textContent = isFavorite ? 'Desfavoritar' : 'Favoritar';
       favoriteOption.classList.toggle('active', isFavorite);
       row.classList.toggle('review-favorite', isFavorite);
-      updateMenuToggle();
-    };
-
-    const paintSoon = () => {
-      soonOption.textContent = isSoon ? 'Remover Em Breve' : 'Em Breve';
-      soonOption.classList.toggle('active', isSoon);
-      row.classList.toggle('review-soon', isSoon);
       updateMenuToggle();
     };
 
@@ -3475,57 +3391,17 @@ function showNatReview(filter=null){
       }
       paintFavorite();
       syncWithReviewState();
-      paintHide();
-      if (!natReviewState.showHidden && isHidden && !isFavorite) {
-        row.remove();
-      }
       ensureEmptyState();
       refreshStats();
       closeMenu();
     });
 
-    soonOption.addEventListener('click', e => {
-      e.preventDefault();
-      isSoon = !isSoon;
-      item.soon = isSoon;
-      if (isSoon) {
-        localStorage.setItem(soonKey, '1');
-      } else {
-        localStorage.removeItem(soonKey);
-      }
-      paintSoon();
-      closeMenu();
-    });
-
-    hideOption.addEventListener('click', e => {
-      e.preventDefault();
-      isHidden = !isHidden;
-      item.hidden = isHidden;
-      if (isHidden) {
-        localStorage.setItem(hiddenKey, '1');
-      } else {
-        localStorage.removeItem(hiddenKey);
-      }
-      autoHidden = false;
-      localStorage.removeItem(autoHiddenKey);
-      natReviewDeferredAutoHide.delete(key);
-      paintHide();
-      syncWithReviewState();
-      if (!natReviewState.showHidden && isHidden && !isFavorite) {
-        row.remove();
-      }
-      ensureEmptyState();
-      refreshStats();
-      closeMenu();
-    });
 
     qBtn.addEventListener('click', () => {
       if (menuOpen) closeMenu();
     });
 
     paintFavorite();
-    paintSoon();
-    paintHide();
 
     row.appendChild(controls);
 

--- a/main.js
+++ b/main.js
@@ -517,7 +517,8 @@ function renderReviewSettingsMenu() {
     btn.type = 'button';
     btn.textContent = REVIEW_MODE_LABELS[mode] || mode;
     if (currentModes.includes(mode)) btn.classList.add('active');
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
       const nextModes = currentModes.includes(mode)
         ? currentModes.filter(item => item !== mode)
         : [...currentModes, mode];
@@ -544,7 +545,8 @@ function renderReviewSettingsMenu() {
     btn.type = 'button';
     btn.textContent = value;
     if (selectedDisciplines.includes(value)) btn.classList.add('active');
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
       const nextDiscs = selectedDisciplines.includes(value)
         ? selectedDisciplines.filter(item => item !== value)
         : [...selectedDisciplines, value];
@@ -2566,8 +2568,11 @@ function openPicker(callback){
     }else if(selected==='__review__'){
       pickerComment.style.display='none';
       pickerMicro.style.display='none';
-      pickerExamMode.style.display='none';
+      pickerExamMode.style.display='';
       pickerExam.style.display='none';
+      pickerExamMode.innerHTML =
+        '<option value="wrong">Erradas</option>'+
+        '<option value="favorite">Favoritas</option>';
       pickerReviewDisc.style.display='';
       pickerSub.style.display='';
       pickerReviewDisc.innerHTML='';
@@ -2655,7 +2660,7 @@ function openPicker(callback){
         alert('Selecione uma disciplina para revisar.');
         return;
       }
-      callback({review:true, mode: reviewMode, disc: reviewDisc, sub: pickerSub.value});
+      callback({review:true, kind: pickerExamMode.value === 'favorite' ? 'favorite' : 'wrong', mode: reviewMode, disc: reviewDisc, sub: pickerSub.value});
     }else{
       callback({disc: pickerDisc.value, sub: pickerSub.value});
     }
@@ -2802,7 +2807,8 @@ function renderTrailDay(day,expand){
         subj.className='trail-subject trail-review';
         const isAllDisc = s.disc === REVIEW_ALL_DISC;
         const hasAll = isAllDisc || s.sub === ALL_SUB;
-        const labelParts = ['Revisão'];
+        const reviewKind = s.kind === 'favorite' ? 'favorite' : 'wrong';
+        const labelParts = [reviewKind === 'favorite' ? 'Revisão (Favoritas)' : 'Revisão (Erradas)'];
         const mode = s.mode || normalizeReviewModes(natReviewState.modes)[0] || 'nat';
         const areaLabel = REVIEW_MODE_LABELS[mode] || 'Área';
         if(isAllDisc){
@@ -2818,13 +2824,13 @@ function renderTrailDay(day,expand){
           trailReturn=dayStr;
           trailReturnSub=false;
           const filter = isAllDisc
-            ? {mode, disc:REVIEW_ALL_DISC}
-            : {mode, disc:s.disc, sub:s.sub};
+            ? {mode, kind: reviewKind, disc:REVIEW_ALL_DISC}
+            : {mode, kind: reviewKind, disc:s.disc, sub:s.sub};
           showNatReview(filter);
         };
         const count=document.createElement('span');
         count.className='trail-count';
-        const countFilter = isAllDisc ? { mode } : { mode, disc:s.disc, sub:s.sub };
+        const countFilter = isAllDisc ? { mode, kind: reviewKind } : { mode, kind: reviewKind, disc:s.disc, sub:s.sub };
         count.textContent=countNatReviewItems(countFilter).toString();
         const rm=document.createElement('button');
         rm.className='trail-remove';
@@ -3318,10 +3324,15 @@ function showNatReview(filter=null){
   currentExamMode = reviewModes[0] || 'nat';
   currentView = 'review';
   currentMicroSimEntry = null;
+  const keepReviewFiltersOpen = !!(reviewSettingsMenu && reviewSettingsMenu.style.display === 'flex');
   leaveHome();
   toggleSettingsVisibility(false);
   toggleReviewSettingsVisibility(true);
   renderReviewSettingsMenu();
+  if (keepReviewFiltersOpen && reviewSettingsMenu && reviewSettingsBtn) {
+    reviewSettingsMenu.style.display = 'flex';
+    reviewSettingsBtn.setAttribute('aria-expanded', 'true');
+  }
   const areaLabel = reviewModes.length
     ? reviewModes.map(mode => REVIEW_MODE_LABELS[mode] || mode).join(' + ')
     : 'Nenhuma área';

--- a/main.js
+++ b/main.js
@@ -1781,17 +1781,32 @@ function showMenu () {
   toggleSettingsVisibility(true);   // mostra engrenagem
 }
 
+function closeProgrammerMenu() {
+  if (!programmerMenu || !programmerBtn) return;
+  programmerMenu.style.display = 'none';
+  programmerBtn.setAttribute('aria-expanded', 'false');
+}
+
+function closeSettingsMenu() {
+  settingsMenu.style.display = "none";
+  closeProgrammerMenu();
+}
+
 // Abre/fecha ao clicar na engrenagem
 settingsBtn.onclick = e => {
   e.stopPropagation();   // evita fechar imediatamente
-  settingsMenu.style.display =
-    settingsMenu.style.display === "flex" ? "none" : "flex";
+  if (settingsMenu.style.display === "flex") {
+    closeSettingsMenu();
+  } else {
+    closeProgrammerMenu();
+    settingsMenu.style.display = "flex";
+  }
 };
 
 // Fecha se clicar fora do menu
 document.addEventListener("click", e=>{
   if(!settingsMenu.contains(e.target) && e.target!==settingsBtn){
-    settingsMenu.style.display = "none";
+    closeSettingsMenu();
   }
   if(
     reviewSettingsMenu && reviewSettingsBtn &&
@@ -1806,7 +1821,7 @@ document.addEventListener("click", e=>{
 function toggleSettingsVisibility(showHome){
   settingsBtn.style.display  = showHome ? 'block' : 'none';
   /* se saiu da home, fecha o menu para não ficar solto */
-  if (!showHome) settingsMenu.style.display = 'none';
+  if (!showHome) closeSettingsMenu();
   toggleReviewSettingsVisibility(false);
 }
 
@@ -2086,7 +2101,7 @@ if (programmerBtn && programmerMenu) {
 
 if (clearAllBtn) {
   clearAllBtn.onclick = async () => {
-    settingsMenu.style.display = 'none';
+    closeSettingsMenu();
     const confirmed = confirm(
       'Deseja apagar tudo? Isso remove questões, comentários, revisões, resumos, manuscritos e cache. Essa ação não pode ser desfeita.'
     );
@@ -2116,7 +2131,7 @@ if (clearAllBtn) {
 
 if (clearQuestionsBtn) {
   clearQuestionsBtn.onclick = () => {
-    settingsMenu.style.display = 'none';
+    closeSettingsMenu();
     const confirmed = confirm(
       'Deseja apagar todos os dados de questões, comentários e revisão? Manuscritos e cache não serão apagados por esta ação.'
     );
@@ -2130,7 +2145,7 @@ if (clearQuestionsBtn) {
 
 if (clearManuscriptsBtn) {
   clearManuscriptsBtn.onclick = () => {
-    settingsMenu.style.display = 'none';
+    closeSettingsMenu();
     const confirmed = confirm(
       'Deseja apagar todos os manuscritos salvos nos PDFs? Essa ação não pode ser desfeita.'
     );
@@ -2157,7 +2172,7 @@ if (clearManuscriptsBtn) {
 
 if (clearCacheBtn) {
   clearCacheBtn.onclick = async () => {
-    settingsMenu.style.display = "none";
+    closeSettingsMenu();
     const confirmed = confirm(
       "Deseja limpar o cache?\nIsso faz o navegador baixar a versão mais recente sem apagar seu progresso."
     );

--- a/main.js
+++ b/main.js
@@ -340,6 +340,7 @@ const clearCacheBtn = document.getElementById("clearCacheBtn");
 const programmerBtn = document.getElementById("programmerBtn");
 const programmerMenu = document.getElementById("programmerMenu");
 const clearQuestionsBtn = document.getElementById("clearQuestionsBtn");
+const clearAllBtn = document.getElementById("clearAllBtn");
 const pickerModal   = document.getElementById("subjectPickerModal");
 const pickerDisc    = document.getElementById("pickerDisc");
 const pickerReviewDisc = document.getElementById("pickerReviewDisc");
@@ -2066,12 +2067,50 @@ if (importHandBtn) {
 }
 
 
+
+async function clearBrowserCaches() {
+  if (!("caches" in window)) return;
+  const cacheNames = await caches.keys();
+  await Promise.all(cacheNames.map(name => caches.delete(name).catch(() => {})));
+}
+
 if (programmerBtn && programmerMenu) {
   programmerBtn.onclick = (event) => {
     event.stopPropagation();
     const expanded = programmerMenu.style.display === 'flex';
     programmerMenu.style.display = expanded ? 'none' : 'flex';
     programmerBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+  };
+}
+
+
+if (clearAllBtn) {
+  clearAllBtn.onclick = async () => {
+    settingsMenu.style.display = 'none';
+    const confirmed = confirm(
+      'Deseja apagar tudo? Isso remove questões, comentários, revisões, resumos, manuscritos e cache. Essa ação não pode ser desfeita.'
+    );
+    if (!confirmed) return;
+
+    try {
+      pdfDirtyLayers.clear();
+    } catch (err) {
+      console.warn('Falha ao limpar a fila de camadas do PDF antes da limpeza total.', err);
+    }
+
+    try {
+      localStorage.clear();
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.clear();
+      }
+      await clearBrowserCaches();
+    } catch (err) {
+      console.error('Erro ao limpar todos os dados', err);
+      alert('Não foi possível concluir a limpeza total. Verifique o console para mais detalhes.');
+      return;
+    }
+
+    window.location.reload();
   };
 }
 
@@ -2128,10 +2167,7 @@ if (clearCacheBtn) {
     clearCacheBtn.textContent = "Limpando...";
 
     try {
-      if ("caches" in window) {
-        const cacheNames = await caches.keys();
-        await Promise.all(cacheNames.map(name => caches.delete(name).catch(() => {})));
-      }
+      await clearBrowserCaches();
 
       const resources = new Set();
       const addLocalResource = url => {

--- a/main.js
+++ b/main.js
@@ -2500,6 +2500,14 @@ function countMicroProgress(entry){
   return a;
 }
 
+function countDailyReviewed(dateStr, filter) {
+  if (!dateStr) return 0;
+  return collectNatReviewItems(filter).reduce((total, item) => {
+    const key = qKey(item.disc, item.sub, item.q.label);
+    return total + (localStorage.getItem(`reviewLog_${dateStr}_${key}`) === '1' ? 1 : 0);
+  }, 0);
+}
+
 function openPicker(callback){
   pickerDisc.innerHTML = '';
   pickerReviewDisc.innerHTML = '';
@@ -2754,6 +2762,7 @@ function renderTrailDay(day,expand){
         const subj=document.createElement('button');
         subj.className='trail-subject trail-review';
         const reviewKind = s.kind === 'favorite' ? 'favorite' : 'wrong';
+        subj.classList.add(reviewKind === 'favorite' ? 'trail-review-favorite' : 'trail-review-wrong');
         subj.textContent = reviewKind === 'favorite' ? 'Revisão (Favoritas)' : 'Revisão (Erradas)';
         subj.onclick=()=>{
           trailReturn=dayStr;
@@ -2769,7 +2778,7 @@ function renderTrailDay(day,expand){
           modes: defaultModes,
           discs: getReviewDisciplinesForModes(defaultModes)
         };
-        count.textContent=countNatReviewItems(countFilter).toString();
+        count.textContent=countDailyReviewed(dayStr, countFilter).toString();
         const rm=document.createElement('button');
         rm.className='trail-remove';
         rm.textContent='\u00D7';
@@ -3452,10 +3461,13 @@ function showNatReview(filter=null){
     };
     reviewBox.onclick = () => {
       reviewState = (reviewState + 1) % 3;
+      const reviewLogKey = `reviewLog_${getTodayStr()}_${key}`;
       if (reviewState === 0) {
         localStorage.removeItem(reviewKey);
+        localStorage.removeItem(reviewLogKey);
       } else {
         localStorage.setItem(reviewKey, reviewState);
+        localStorage.setItem(reviewLogKey, '1');
       }
       paintReview();
       syncWithReviewState();

--- a/main.js
+++ b/main.js
@@ -356,6 +356,10 @@ const trilhaBtn     = document.getElementById("trilhaBtn");
 const examsBtn      = document.getElementById("examsBtn");
 const natReviewBtn  = document.getElementById("natReviewBtn");
 const favReviewBtn  = document.getElementById("favReviewBtn");
+const reviewMenuBtn = document.getElementById("reviewMenuBtn");
+const reviewMenu = document.getElementById("reviewMenu");
+const backupMenuBtn = document.getElementById("backupMenuBtn");
+const backupMenu = document.getElementById("backupMenu");
 const reviewModeBtn = document.getElementById("reviewModeBtn");
 const clearManuscriptsBtn = document.getElementById("clearManuscriptsBtn");
 const clearCacheBtn = document.getElementById("clearCacheBtn");
@@ -1897,15 +1901,33 @@ function showMenu () {
   toggleSettingsVisibility(true);   // mostra engrenagem
 }
 
+function closeSubmenu(menu, button) {
+  if (!menu || !button) return;
+  menu.style.display = 'none';
+  button.setAttribute('aria-expanded', 'false');
+}
+
 function closeProgrammerMenu() {
-  if (!programmerMenu || !programmerBtn) return;
-  programmerMenu.style.display = 'none';
-  programmerBtn.setAttribute('aria-expanded', 'false');
+  closeSubmenu(programmerMenu, programmerBtn);
+}
+
+function closeSettingsSubmenus() {
+  closeSubmenu(reviewMenu, reviewMenuBtn);
+  closeSubmenu(backupMenu, backupMenuBtn);
+  closeProgrammerMenu();
 }
 
 function closeSettingsMenu() {
   settingsMenu.style.display = "none";
-  closeProgrammerMenu();
+  closeSettingsSubmenus();
+}
+
+function toggleSettingsSubmenu(menu, button) {
+  if (!menu || !button) return;
+  const expanded = menu.style.display === 'flex';
+  closeSettingsSubmenus();
+  menu.style.display = expanded ? 'none' : 'flex';
+  button.setAttribute('aria-expanded', expanded ? 'false' : 'true');
 }
 
 // Abre/fecha ao clicar na engrenagem
@@ -1914,7 +1936,7 @@ settingsBtn.onclick = e => {
   if (settingsMenu.style.display === "flex") {
     closeSettingsMenu();
   } else {
-    closeProgrammerMenu();
+    closeSettingsSubmenus();
     settingsMenu.style.display = "flex";
   }
 };
@@ -2142,7 +2164,7 @@ function renderSearchResults(results){
 
 if(searchNotesBtn){
   searchNotesBtn.onclick = () => {
-    settingsMenu.style.display = 'none';
+    closeSettingsMenu();
     openSearchOverlay();
   };
 }
@@ -2173,24 +2195,24 @@ document.addEventListener('keydown', e => {
 });
 
 exportBtn.onclick = () => {
-  settingsMenu.style.display = "none";
+  closeSettingsMenu();
   exportData('general');
 };
 if (exportHandBtn) {
   exportHandBtn.onclick = () => {
-    settingsMenu.style.display = "none";
+    closeSettingsMenu();
     exportData('handwriting');
   };
 }
 importBtn.onclick = () => {
-  settingsMenu.style.display = "none";
+  closeSettingsMenu();
   importFile.value = '';
   importFile.dataset.mode = 'general';
   importFile.click();
 };
 if (importHandBtn) {
   importHandBtn.onclick = () => {
-    settingsMenu.style.display = "none";
+    closeSettingsMenu();
     importFile.value = '';
     importFile.dataset.mode = 'handwriting';
     importFile.click();
@@ -2205,12 +2227,24 @@ async function clearBrowserCaches() {
   await Promise.all(cacheNames.map(name => caches.delete(name).catch(() => {})));
 }
 
+if (reviewMenuBtn && reviewMenu) {
+  reviewMenuBtn.onclick = (event) => {
+    event.stopPropagation();
+    toggleSettingsSubmenu(reviewMenu, reviewMenuBtn);
+  };
+}
+
+if (backupMenuBtn && backupMenu) {
+  backupMenuBtn.onclick = (event) => {
+    event.stopPropagation();
+    toggleSettingsSubmenu(backupMenu, backupMenuBtn);
+  };
+}
+
 if (programmerBtn && programmerMenu) {
   programmerBtn.onclick = (event) => {
     event.stopPropagation();
-    const expanded = programmerMenu.style.display === 'flex';
-    programmerMenu.style.display = expanded ? 'none' : 'flex';
-    programmerBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+    toggleSettingsSubmenu(programmerMenu, programmerBtn);
   };
 }
 
@@ -2334,24 +2368,24 @@ if (clearCacheBtn) {
 
 /* ---------------- TRILHA ESTRATÉGICA ---------------- */
 trilhaBtn.onclick = () => {
-  settingsMenu.style.display = 'none';
+  closeSettingsMenu();
   showTrail();
 };
 
 examsBtn.onclick = () => {
-  settingsMenu.style.display = "none";
+  closeSettingsMenu();
   showExamMenu();
 };
 
 natReviewBtn.onclick = () => {
-  settingsMenu.style.display = 'none';
+  closeSettingsMenu();
   resetNatReviewState('wrong');
   showNatReview();
 };
 
 if (favReviewBtn) {
   favReviewBtn.onclick = () => {
-    settingsMenu.style.display = 'none';
+    closeSettingsMenu();
     resetNatReviewState('favorite');
     showNatReview();
   };
@@ -2360,7 +2394,7 @@ if (favReviewBtn) {
 if (reviewModeBtn) {
   updateReviewModeButton();
   reviewModeBtn.onclick = () => {
-    settingsMenu.style.display = 'none';
+    closeSettingsMenu();
     setPostReviewMode(!postReviewMode);
   };
 }
@@ -2372,7 +2406,7 @@ function updateD1Btn(){
 toggleD1Btn.onclick = () => {
   d1Enabled = !d1Enabled;
   localStorage.setItem('d1Enabled', JSON.stringify(d1Enabled));
-  settingsMenu.style.display = 'none';
+  closeSettingsMenu();
   updateD1Btn();
   if(currentDisc === null) showMenu();
 };

--- a/main.js
+++ b/main.js
@@ -269,7 +269,6 @@ const NAT_REVIEW_AUTO_HIDDEN_PREFIX = 'natReviewAutoHidden_';
 const NAT_REVIEW_FAVORITE_PREFIX = 'natReviewFav_';
 const NAT_REVIEW_SOON_PREFIX = 'natReviewSoon_';
 const NAT_REVIEW_SHOW_HIDDEN_STORAGE_KEY = 'natReviewShowHidden';
-const NAT_REVIEW_SHOW_PENDING_STORAGE_KEY = 'natReviewShowPending';
 const natReviewDeferredAutoHide = new Set();
 
 const REVIEW_MODE_STORAGE_KEY = 'postReviewModeEnabled';
@@ -279,7 +278,6 @@ const DEFAULT_NAT_REVIEW_STATE = {
   disc: REVIEW_ALL_DISC,
   sub: null,
   showHidden: localStorage.getItem(NAT_REVIEW_SHOW_HIDDEN_STORAGE_KEY) === '1',
-  showPending: localStorage.getItem(NAT_REVIEW_SHOW_PENDING_STORAGE_KEY) === '1',
 };
 
 let natReviewState = { ...DEFAULT_NAT_REVIEW_STATE };
@@ -382,9 +380,6 @@ function setNatReviewState(partial = {}) {
   if (partial.showHidden !== undefined) {
     next.showHidden = !!partial.showHidden;
   }
-  if (partial.showPending !== undefined) {
-    next.showPending = !!partial.showPending;
-  }
   if (!next.mode) {
     next.mode = 'nat';
   }
@@ -392,10 +387,6 @@ function setNatReviewState(partial = {}) {
   localStorage.setItem(
     NAT_REVIEW_SHOW_HIDDEN_STORAGE_KEY,
     natReviewState.showHidden ? '1' : '0'
-  );
-  localStorage.setItem(
-    NAT_REVIEW_SHOW_PENDING_STORAGE_KEY,
-    natReviewState.showPending ? '1' : '0'
   );
   return natReviewState;
 }
@@ -512,24 +503,6 @@ function renderReviewSettingsMenu() {
     optionsWrap.appendChild(btn);
   });
   reviewSettingsMenu.appendChild(optionsWrap);
-
-  const divider = document.createElement('div');
-  divider.className = 'review-menu-divider';
-  reviewSettingsMenu.appendChild(divider);
-
-  const pendingBtn = document.createElement('button');
-  pendingBtn.className = 'review-menu-option review-menu-toggle';
-  pendingBtn.type = 'button';
-  const showPending = !!natReviewState.showPending;
-  pendingBtn.textContent = showPending ? 'Ocultar Não Feitas' : 'Exibir Não Feitas';
-  if (showPending) pendingBtn.classList.add('active');
-  pendingBtn.addEventListener('click', () => {
-    setNatReviewState({ showPending: !natReviewState.showPending });
-    reviewSettingsMenu.style.display = 'none';
-    reviewSettingsBtn.setAttribute('aria-expanded', 'false');
-    showNatReview();
-  });
-  reviewSettingsMenu.appendChild(pendingBtn);
 
   if (wasOpen) {
     reviewSettingsMenu.style.display = 'flex';
@@ -2919,9 +2892,6 @@ function collectNatReviewItems(filter=null){
   const combined = [];
   const pushQuestionsFromExam = exam => {
     const questions = areaData[exam] || [];
-    const upper = exam.toUpperCase();
-    const isEnem = upper.includes('ENEM');
-    const isSas  = upper.includes('SAS');
     questions.forEach(({disc,sub,q})=>{
       if(!matchesFilter(disc,sub)) return;
       const key = qKey(disc,sub,q.label);
@@ -2931,9 +2901,6 @@ function collectNatReviewItems(filter=null){
       const isFavorite = localStorage.getItem(favoriteKey) === '1';
       if(effectiveState === 2){
         combined.push({exam,mode,disc,sub,q,type:'wrong',favorite:isFavorite});
-      }
-      if(isEnem && effectiveState === 0){
-        combined.push({exam,mode,disc,sub,q,type:'pending',favorite:isFavorite});
       }
     });
     visited.add(exam);
@@ -2947,31 +2914,22 @@ function collectNatReviewItems(filter=null){
 
 function computeNatReviewSnapshot(items){
   if (typeof localStorage === 'undefined') {
-    return { wrongCount: 0, pendingCount: 0, totalCount: 0, reviewedCount: 0 };
+    return { wrongCount: 0, totalCount: 0, reviewedCount: 0 };
   }
   let wrongCount = 0;
-  let pendingCount = 0;
   let reviewedCount = 0;
   items.forEach(item=>{
     const key = qKey(item.disc,item.sub,item.q.label);
-    const state = getStoredQuestionState(item.disc, item.sub, item.q.label);
-    const effectiveState = getEffectiveStateFromKey(key, state);
-    const isWrongItem = item.type === 'wrong';
-    const qualifies = isWrongItem ? effectiveState === 2 : effectiveState === 0;
-    if(!qualifies) return;
-    if(isWrongItem){
-      wrongCount += 1;
-    }else{
-      pendingCount += 1;
-    }
+    const effectiveState = getEffectiveQuestionState(item.disc, item.sub, item.q.label);
+    if(effectiveState !== 2) return;
+    wrongCount += 1;
     const reviewKey = `natReview_${key}`;
     const reviewState = +localStorage.getItem(reviewKey) || 0;
     if(reviewState > 0){
       reviewedCount += 1;
     }
   });
-  const totalCount = wrongCount + pendingCount;
-  return { wrongCount, pendingCount, totalCount, reviewedCount };
+  return { wrongCount, totalCount: wrongCount, reviewedCount };
 }
 
 function countNatReviewItems(filter=null){
@@ -2984,9 +2942,7 @@ function countNatReviewItems(filter=null){
     return next;
   })();
   const combined = collectNatReviewItems(effectiveFilter);
-  const showPending = natReviewState.showPending;
-  const filteredItems = combined.filter(item => showPending || item.type !== 'pending');
-  const snapshot = computeNatReviewSnapshot(filteredItems);
+  const snapshot = computeNatReviewSnapshot(combined);
   return Math.max(snapshot.totalCount - snapshot.reviewedCount, 0);
 }
 /* ---------------- LISTA DE ASSUNTOS ---------------- */
@@ -3163,7 +3119,7 @@ function showNatReview(filter=null){
   if(filter){
     setNatReviewState(filter);
   }
-  const { mode: reviewMode = 'nat', disc, sub, showPending } = natReviewState;
+  const { mode: reviewMode = 'nat', disc, sub } = natReviewState;
   const isAll = disc === REVIEW_ALL_DISC;
   const effectiveFilter = isAll
     ? { mode: reviewMode }
@@ -3202,9 +3158,7 @@ function showNatReview(filter=null){
   clear();
   window.scrollTo(0,0);
 
-  const combined = collectNatReviewItems(effectiveFilter);
-  const itemsForView = combined.filter(item => showPending || item.type !== 'pending');
-  const pendingFilteredOut = !showPending && combined.some(item => item.type === 'pending');
+  const itemsForView = collectNatReviewItems(effectiveFilter);
   const baseEmptyText = (!isAll || (sub && sub !== ALL_SUB))
     ? 'Nenhuma questão para revisar no filtro escolhido.'
     : 'Nenhuma questão errada ou pendente encontrada nos simulados.';
@@ -3217,19 +3171,15 @@ function showNatReview(filter=null){
     if (hasRow) {
       if (emptyMsg.isConnected) emptyMsg.remove();
     } else {
-      let message = baseEmptyText;
-      if (pendingFilteredOut) {
-        message = 'Ative “Exibir Não Feitas” para ver as questões pendentes.';
-      }
-      emptyMsg.textContent = message;
+      emptyMsg.textContent = baseEmptyText;
       if (!emptyMsg.isConnected) app.appendChild(emptyMsg);
     }
   };
 
   const refreshStats = () => {
     const snapshot = computeNatReviewSnapshot(itemsForView);
-    const { wrongCount, pendingCount, reviewedCount, totalCount } = snapshot;
-    const text = `Erradas (todos os simulados): ${wrongCount} | Não feitas ENEM: ${pendingCount} | Total visível: ${reviewedCount}/${totalCount}`;
+    const { wrongCount, reviewedCount, totalCount } = snapshot;
+    const text = `Erradas (todos os simulados): ${wrongCount} | Revisadas: ${reviewedCount}/${totalCount}`;
     stats.textContent = text;
     stats.className = 'stat';
   };
@@ -3241,8 +3191,7 @@ function showNatReview(filter=null){
     let st = getStoredQuestionState(item.disc, item.sub, item.q.label);
     const qualifies = () => {
       const effective = getEffectiveStateFromKey(key, st);
-      if (item.type === 'wrong') return effective === 2;
-      return effective === 0;
+      return effective === 2;
     };
     if (!qualifies()) return;
 

--- a/main.js
+++ b/main.js
@@ -256,19 +256,35 @@ const UNCLASSIFIED_DISCIPLINES_BY_MODE = {
 };
 
 function getReviewDisciplineOptions(mode){
-  if (mode === REVIEW_ALL_MODE) {
-    const all = Object.keys(DISCIPLINES_BY_MODE).flatMap(key => getReviewDisciplineOptions(key));
-    return [...new Set(all)];
-  }
   const list = DISCIPLINES_BY_MODE[mode] || [];
   const unclassified = UNCLASSIFIED_DISCIPLINES_BY_MODE[mode];
-  return unclassified ? list.filter(disc => disc !== unclassified) : list.slice();
+  return list.filter(disc => disc !== unclassified && disc !== 'Redação');
 }
 
-const REVIEW_ALL_MODE = 'all';
-const REVIEW_MODE_LABELS = { all: 'Todas', lin: 'Linguagens', hum: 'Humanas', nat: 'Natureza', mat: 'Matemática' };
+const REVIEW_DEFAULT_MODES = ['nat', 'mat'];
+const REVIEW_MODE_LABELS = { lin: 'Linguagens', hum: 'Humanas', nat: 'Natureza', mat: 'Matemática' };
 const REVIEW_MODES = Object.keys(REVIEW_MODE_LABELS);
 const REVIEW_ALL_DISC = '__review_all__';
+
+function getReviewDisciplinesForModes(modes = REVIEW_DEFAULT_MODES) {
+  return [...new Set(modes.flatMap(mode => getReviewDisciplineOptions(mode)))];
+}
+
+function normalizeReviewModes(modes) {
+  const normalized = Array.isArray(modes)
+    ? modes.filter(mode => REVIEW_MODES.includes(mode))
+    : [];
+  return [...new Set(normalized)];
+}
+
+function normalizeReviewDiscs(discs, modes) {
+  const allowed = new Set(getReviewDisciplinesForModes(modes));
+  const normalized = Array.isArray(discs)
+    ? discs.filter(disc => allowed.has(disc))
+    : [];
+  return [...new Set(normalized)];
+}
+
 const NAT_REVIEW_HIDDEN_PREFIX = 'natReviewHidden_';
 const NAT_REVIEW_AUTO_HIDDEN_PREFIX = 'natReviewAutoHidden_';
 const NAT_REVIEW_FAVORITE_PREFIX = 'natReviewFav_';
@@ -279,7 +295,8 @@ const natReviewDeferredAutoHide = new Set();
 const REVIEW_MODE_STORAGE_KEY = 'postReviewModeEnabled';
 
 const DEFAULT_NAT_REVIEW_STATE = {
-  mode: REVIEW_ALL_MODE,
+  modes: REVIEW_DEFAULT_MODES.slice(),
+  discs: getReviewDisciplinesForModes(REVIEW_DEFAULT_MODES),
   disc: REVIEW_ALL_DISC,
   sub: null,
   kind: 'wrong',
@@ -368,8 +385,16 @@ const searchCloseBtn = document.getElementById("searchCloseBtn");
 
 function setNatReviewState(partial = {}) {
   const next = { ...natReviewState };
-  if (partial.mode !== undefined && partial.mode !== next.mode) {
-    next.mode = partial.mode;
+  if (partial.modes !== undefined || partial.mode !== undefined) {
+    const requestedModes = partial.modes !== undefined ? partial.modes : [partial.mode];
+    next.modes = normalizeReviewModes(requestedModes);
+    next.discs = normalizeReviewDiscs(partial.discs !== undefined ? partial.discs : next.discs, next.modes);
+    next.disc = REVIEW_ALL_DISC;
+    next.sub = null;
+  }
+  if (partial.discs !== undefined) {
+    const modes = normalizeReviewModes(next.modes);
+    next.discs = normalizeReviewDiscs(partial.discs, modes);
     next.disc = REVIEW_ALL_DISC;
     next.sub = null;
   }
@@ -377,8 +402,15 @@ function setNatReviewState(partial = {}) {
     next.disc = partial.disc;
     if (partial.disc === REVIEW_ALL_DISC) {
       next.sub = null;
-    } else if (partial.sub === undefined && natReviewState.disc !== partial.disc) {
-      next.sub = null;
+    } else {
+      const modes = normalizeReviewModes(next.modes);
+      const allowed = new Set(getReviewDisciplinesForModes(modes));
+      if (allowed.has(partial.disc) && !next.discs.includes(partial.disc)) {
+        next.discs = [...next.discs, partial.disc];
+      }
+      if (partial.sub === undefined && natReviewState.disc !== partial.disc) {
+        next.sub = null;
+      }
     }
   }
   if (partial.sub !== undefined) {
@@ -390,9 +422,8 @@ function setNatReviewState(partial = {}) {
   if (partial.showHidden !== undefined) {
     next.showHidden = !!partial.showHidden;
   }
-  if (!next.mode) {
-    next.mode = REVIEW_ALL_MODE;
-  }
+  next.modes = normalizeReviewModes(next.modes);
+  next.discs = normalizeReviewDiscs(next.discs, next.modes);
   natReviewState = next;
   localStorage.setItem(
     NAT_REVIEW_SHOW_HIDDEN_STORAGE_KEY,
@@ -402,7 +433,13 @@ function setNatReviewState(partial = {}) {
 }
 
 function resetNatReviewState(kind = 'wrong') {
-  setNatReviewState({ mode: REVIEW_ALL_MODE, disc: REVIEW_ALL_DISC, sub: null, kind });
+  setNatReviewState({
+    modes: REVIEW_DEFAULT_MODES.slice(),
+    discs: getReviewDisciplinesForModes(REVIEW_DEFAULT_MODES),
+    disc: REVIEW_ALL_DISC,
+    sub: null,
+    kind
+  });
 }
 
 function ensureReviewSettingsUI() {
@@ -469,17 +506,19 @@ function renderReviewSettingsMenu() {
 
   const areaWrap = document.createElement('div');
   areaWrap.className = 'review-menu-options';
-  const currentMode = natReviewState.mode || REVIEW_ALL_MODE;
+  const currentModes = normalizeReviewModes(natReviewState.modes);
   REVIEW_MODES.forEach(mode => {
     const btn = document.createElement('button');
     btn.className = 'review-menu-option';
     btn.type = 'button';
     btn.textContent = REVIEW_MODE_LABELS[mode] || mode;
-    if (mode === currentMode) btn.classList.add('active');
+    if (currentModes.includes(mode)) btn.classList.add('active');
     btn.addEventListener('click', () => {
-      setNatReviewState({ mode, disc: REVIEW_ALL_DISC, sub: null });
-      reviewSettingsMenu.style.display = 'none';
-      reviewSettingsBtn.setAttribute('aria-expanded', 'false');
+      const nextModes = currentModes.includes(mode)
+        ? currentModes.filter(item => item !== mode)
+        : [...currentModes, mode];
+      const nextDiscs = getReviewDisciplinesForModes(nextModes);
+      setNatReviewState({ modes: nextModes, discs: nextDiscs });
       showNatReview();
     });
     areaWrap.appendChild(btn);
@@ -493,21 +532,19 @@ function renderReviewSettingsMenu() {
 
   const optionsWrap = document.createElement('div');
   optionsWrap.className = 'review-menu-options';
-  const areaLabel = REVIEW_MODE_LABELS[currentMode] || 'Área';
-  const disciplineOptions = [REVIEW_ALL_DISC, ...getReviewDisciplineOptions(currentMode)];
+  const disciplineOptions = getReviewDisciplinesForModes(currentModes);
+  const selectedDisciplines = normalizeReviewDiscs(natReviewState.discs, currentModes);
   disciplineOptions.forEach(value => {
     const btn = document.createElement('button');
     btn.className = 'review-menu-option';
     btn.type = 'button';
-    btn.textContent = value === REVIEW_ALL_DISC ? 'Todas' : value;
-    const isSelected =
-      (value === REVIEW_ALL_DISC && natReviewState.disc === REVIEW_ALL_DISC) ||
-      natReviewState.disc === value;
-    if (isSelected) btn.classList.add('active');
+    btn.textContent = value;
+    if (selectedDisciplines.includes(value)) btn.classList.add('active');
     btn.addEventListener('click', () => {
-      setNatReviewState({ disc: value, sub: null });
-      reviewSettingsMenu.style.display = 'none';
-      reviewSettingsBtn.setAttribute('aria-expanded', 'false');
+      const nextDiscs = selectedDisciplines.includes(value)
+        ? selectedDisciplines.filter(item => item !== value)
+        : [...selectedDisciplines, value];
+      setNatReviewState({ discs: nextDiscs });
       showNatReview();
     });
     optionsWrap.appendChild(btn);
@@ -2500,7 +2537,7 @@ function openPicker(callback){
       pickerReviewDisc.style.display='';
       pickerSub.style.display='';
       pickerReviewDisc.innerHTML='';
-      const reviewMode = natReviewState.mode || 'nat';
+      const reviewMode = normalizeReviewModes(natReviewState.modes)[0] || 'nat';
       const reviewAreaLabel = REVIEW_MODE_LABELS[reviewMode] || 'Área';
       const optAllDisc=document.createElement('option');
       optAllDisc.value=REVIEW_ALL_DISC;
@@ -2732,7 +2769,7 @@ function renderTrailDay(day,expand){
         const isAllDisc = s.disc === REVIEW_ALL_DISC;
         const hasAll = isAllDisc || s.sub === ALL_SUB;
         const labelParts = ['Revisão'];
-        const mode = s.mode || natReviewState.mode || 'nat';
+        const mode = s.mode || normalizeReviewModes(natReviewState.modes)[0] || 'nat';
         const areaLabel = REVIEW_MODE_LABELS[mode] || 'Área';
         if(isAllDisc){
           labelParts.push(areaLabel);
@@ -2984,14 +3021,14 @@ function renderExamSummary(){
 }
 
 function collectNatReviewItems(filter=null){
-  const mode = filter?.mode || natReviewState.mode || REVIEW_ALL_MODE;
+  const modes = normalizeReviewModes(filter?.modes || (filter?.mode ? [filter.mode] : natReviewState.modes));
+  const selectedDisciplines = new Set(normalizeReviewDiscs(filter?.discs || natReviewState.discs, modes));
   const kind = filter?.kind || natReviewState.kind || 'wrong';
   const normalizedFilter = (() => {
     if (!filter) return null;
     const { disc, sub } = filter.disc === REVIEW_ALL_DISC ? { disc: null, sub: null } : filter;
     return { disc: disc ?? null, sub: sub ?? null };
   })();
-  const modes = mode === REVIEW_ALL_MODE ? Object.keys(DISCIPLINES_BY_MODE) : [mode];
   const combined = [];
   modes.forEach(currentMode => {
     const areaData = examsDataByMode[currentMode] || {};
@@ -3000,6 +3037,7 @@ function collectNatReviewItems(filter=null){
     const allowed = new Set(DISCIPLINES_BY_MODE[currentMode] || []);
     const matchesFilter = (disc, sub) => {
       if(!allowed.has(disc)) return false;
+      if(!selectedDisciplines.has(disc)) return false;
       if(normalizedFilter?.disc && disc !== normalizedFilter.disc) return false;
       if(normalizedFilter?.sub && normalizedFilter.sub !== ALL_SUB && sub !== normalizedFilter.sub) return false;
       return true;
@@ -3232,23 +3270,27 @@ function showNatReview(filter=null){
   if(filter){
     setNatReviewState(filter);
   }
-  const { mode: reviewMode = REVIEW_ALL_MODE, disc, sub, kind: reviewKind = 'wrong' } = natReviewState;
+  const { disc, sub, kind: reviewKind = 'wrong' } = natReviewState;
+  const reviewModes = normalizeReviewModes(natReviewState.modes);
+  const reviewDiscs = normalizeReviewDiscs(natReviewState.discs, reviewModes);
   const isAll = disc === REVIEW_ALL_DISC;
   const effectiveFilter = isAll
-    ? { mode: reviewMode, kind: reviewKind }
-    : { mode: reviewMode, disc, sub, kind: reviewKind };
+    ? { modes: reviewModes, discs: reviewDiscs, kind: reviewKind }
+    : { modes: reviewModes, discs: reviewDiscs, disc, sub, kind: reviewKind };
   currentDisc = null;
   currentSub = null;
   currentExam = null;
   examListOpen = false;
-  currentExamMode = reviewMode;
+  currentExamMode = reviewModes[0] || 'nat';
   currentView = 'review';
   currentMicroSimEntry = null;
   leaveHome();
   toggleSettingsVisibility(false);
   toggleReviewSettingsVisibility(true);
   renderReviewSettingsMenu();
-  const areaLabel = REVIEW_MODE_LABELS[reviewMode] || 'Todas';
+  const areaLabel = reviewModes.length
+    ? reviewModes.map(mode => REVIEW_MODE_LABELS[mode] || mode).join(' + ')
+    : 'Nenhuma área';
   const reviewTitle = reviewKind === 'favorite' ? 'Revisão (Favoritas)' : 'Revisão (Erradas)';
   let headerLabel = `${reviewTitle}: ${areaLabel}`;
   if(!isAll){

--- a/main.js
+++ b/main.js
@@ -256,12 +256,17 @@ const UNCLASSIFIED_DISCIPLINES_BY_MODE = {
 };
 
 function getReviewDisciplineOptions(mode){
+  if (mode === REVIEW_ALL_MODE) {
+    const all = Object.keys(DISCIPLINES_BY_MODE).flatMap(key => getReviewDisciplineOptions(key));
+    return [...new Set(all)];
+  }
   const list = DISCIPLINES_BY_MODE[mode] || [];
   const unclassified = UNCLASSIFIED_DISCIPLINES_BY_MODE[mode];
   return unclassified ? list.filter(disc => disc !== unclassified) : list.slice();
 }
 
-const REVIEW_MODE_LABELS = { lin: 'Linguagens', hum: 'Humanas', nat: 'Natureza', mat: 'Matemática' };
+const REVIEW_ALL_MODE = 'all';
+const REVIEW_MODE_LABELS = { all: 'Todas', lin: 'Linguagens', hum: 'Humanas', nat: 'Natureza', mat: 'Matemática' };
 const REVIEW_MODES = Object.keys(REVIEW_MODE_LABELS);
 const REVIEW_ALL_DISC = '__review_all__';
 const NAT_REVIEW_HIDDEN_PREFIX = 'natReviewHidden_';
@@ -274,9 +279,10 @@ const natReviewDeferredAutoHide = new Set();
 const REVIEW_MODE_STORAGE_KEY = 'postReviewModeEnabled';
 
 const DEFAULT_NAT_REVIEW_STATE = {
-  mode: 'nat',
+  mode: REVIEW_ALL_MODE,
   disc: REVIEW_ALL_DISC,
   sub: null,
+  kind: 'wrong',
   showHidden: localStorage.getItem(NAT_REVIEW_SHOW_HIDDEN_STORAGE_KEY) === '1',
 };
 
@@ -332,6 +338,7 @@ const importHandBtn = document.getElementById("importHandBtn");
 const trilhaBtn     = document.getElementById("trilhaBtn");
 const examsBtn      = document.getElementById("examsBtn");
 const natReviewBtn  = document.getElementById("natReviewBtn");
+const favReviewBtn  = document.getElementById("favReviewBtn");
 const reviewModeBtn = document.getElementById("reviewModeBtn");
 const clearManuscriptsBtn = document.getElementById("clearManuscriptsBtn");
 const clearCacheBtn = document.getElementById("clearCacheBtn");
@@ -377,11 +384,14 @@ function setNatReviewState(partial = {}) {
   if (partial.sub !== undefined) {
     next.sub = partial.sub;
   }
+  if (partial.kind !== undefined) {
+    next.kind = partial.kind === 'favorite' ? 'favorite' : 'wrong';
+  }
   if (partial.showHidden !== undefined) {
     next.showHidden = !!partial.showHidden;
   }
   if (!next.mode) {
-    next.mode = 'nat';
+    next.mode = REVIEW_ALL_MODE;
   }
   natReviewState = next;
   localStorage.setItem(
@@ -391,8 +401,8 @@ function setNatReviewState(partial = {}) {
   return natReviewState;
 }
 
-function resetNatReviewState() {
-  setNatReviewState({ mode: 'nat', disc: REVIEW_ALL_DISC, sub: null });
+function resetNatReviewState(kind = 'wrong') {
+  setNatReviewState({ mode: REVIEW_ALL_MODE, disc: REVIEW_ALL_DISC, sub: null, kind });
 }
 
 function ensureReviewSettingsUI() {
@@ -459,7 +469,7 @@ function renderReviewSettingsMenu() {
 
   const areaWrap = document.createElement('div');
   areaWrap.className = 'review-menu-options';
-  const currentMode = natReviewState.mode || 'nat';
+  const currentMode = natReviewState.mode || REVIEW_ALL_MODE;
   REVIEW_MODES.forEach(mode => {
     const btn = document.createElement('button');
     btn.className = 'review-menu-option';
@@ -489,7 +499,7 @@ function renderReviewSettingsMenu() {
     const btn = document.createElement('button');
     btn.className = 'review-menu-option';
     btn.type = 'button';
-    btn.textContent = value === REVIEW_ALL_DISC ? areaLabel : value;
+    btn.textContent = value === REVIEW_ALL_DISC ? 'Todas' : value;
     const isSelected =
       (value === REVIEW_ALL_DISC && natReviewState.disc === REVIEW_ALL_DISC) ||
       natReviewState.disc === value;
@@ -1095,6 +1105,102 @@ function clearQuestionDataFromLocalStorage() {
   }
   keysToRemove.forEach((key) => localStorage.removeItem(key));
   return keysToRemove.length;
+}
+
+
+function attachFavoriteQuestionMenu(row, qBtn, disc, sub, label, onChange = null) {
+  const key = qKey(disc, sub, label);
+  const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
+  let isFavorite = localStorage.getItem(favoriteKey) === '1';
+
+  qBtn.classList.add('question-btn--with-menu');
+  row.classList.toggle('review-favorite', isFavorite);
+
+  const menuToggle = document.createElement('span');
+  menuToggle.className = 'question-menu-toggle';
+  menuToggle.textContent = '▾';
+  menuToggle.title = 'Ações da questão';
+  menuToggle.setAttribute('aria-haspopup', 'menu');
+  menuToggle.setAttribute('aria-expanded', 'false');
+  qBtn.appendChild(menuToggle);
+
+  const actionMenu = document.createElement('div');
+  actionMenu.className = 'question-action-menu';
+  actionMenu.style.display = 'none';
+
+  const favoriteOption = document.createElement('button');
+  favoriteOption.type = 'button';
+  favoriteOption.className = 'question-action-option';
+  actionMenu.appendChild(favoriteOption);
+  row.appendChild(actionMenu);
+
+  const updateMenuToggle = () => {
+    menuToggle.classList.toggle('menu-active', isFavorite);
+  };
+
+  const paintFavorite = () => {
+    favoriteOption.textContent = isFavorite ? 'Desfavoritar' : 'Favoritar';
+    favoriteOption.classList.toggle('active', isFavorite);
+    row.classList.toggle('review-favorite', isFavorite);
+    updateMenuToggle();
+  };
+
+  let menuOpen = false;
+  const onOutsideClick = event => {
+    if (!row.contains(event.target)) closeMenu();
+  };
+  const closeMenu = () => {
+    if (!menuOpen) return;
+    menuOpen = false;
+    actionMenu.style.display = 'none';
+    menuToggle.classList.remove('open');
+    menuToggle.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', onOutsideClick);
+    row.style.zIndex = '';
+  };
+  const openMenu = () => {
+    if (menuOpen) return;
+    menuOpen = true;
+    row.style.zIndex = '30';
+    actionMenu.style.display = 'block';
+    actionMenu.style.visibility = 'hidden';
+    const toggleRect = menuToggle.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
+    const menuRect = actionMenu.getBoundingClientRect();
+    const maxLeft = Math.max(rowRect.width - menuRect.width, 0);
+    const desiredLeft = Math.max(toggleRect.right - rowRect.left - menuRect.width, 0);
+    actionMenu.style.left = `${Math.min(desiredLeft, maxLeft)}px`;
+    actionMenu.style.top = `${toggleRect.bottom - rowRect.top + 4}px`;
+    actionMenu.style.visibility = 'visible';
+    menuToggle.classList.add('open');
+    menuToggle.setAttribute('aria-expanded', 'true');
+    document.addEventListener('click', onOutsideClick);
+  };
+
+  menuToggle.addEventListener('click', e => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (menuOpen) closeMenu();
+    else openMenu();
+  });
+
+  favoriteOption.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    isFavorite = !isFavorite;
+    if (isFavorite) localStorage.setItem(favoriteKey, '1');
+    else localStorage.removeItem(favoriteKey);
+    paintFavorite();
+    if (typeof onChange === 'function') onChange(isFavorite, { row, closeMenu });
+    closeMenu();
+  });
+
+  qBtn.addEventListener('click', () => {
+    if (menuOpen) closeMenu();
+  });
+
+  paintFavorite();
+  return { closeMenu, paintFavorite, get isFavorite() { return isFavorite; } };
 }
 
 function getExportFilenamePrefix(mode) {
@@ -2202,9 +2308,17 @@ examsBtn.onclick = () => {
 
 natReviewBtn.onclick = () => {
   settingsMenu.style.display = 'none';
-  resetNatReviewState();
+  resetNatReviewState('wrong');
   showNatReview();
 };
+
+if (favReviewBtn) {
+  favReviewBtn.onclick = () => {
+    settingsMenu.style.display = 'none';
+    resetNatReviewState('favorite');
+    showNatReview();
+  };
+}
 
 if (reviewModeBtn) {
   updateReviewModeButton();
@@ -2870,66 +2984,64 @@ function renderExamSummary(){
 }
 
 function collectNatReviewItems(filter=null){
-  const mode = filter?.mode || natReviewState.mode || 'nat';
+  const mode = filter?.mode || natReviewState.mode || REVIEW_ALL_MODE;
+  const kind = filter?.kind || natReviewState.kind || 'wrong';
   const normalizedFilter = (() => {
     if (!filter) return null;
     const { disc, sub } = filter.disc === REVIEW_ALL_DISC ? { disc: null, sub: null } : filter;
-    return {
-      disc: disc ?? null,
-      sub: sub ?? null
-    };
+    return { disc: disc ?? null, sub: sub ?? null };
   })();
-  const areaData = examsDataByMode[mode] || {};
-  const examOrder = examOrderByMode[mode] || [];
-  const visited = new Set();
-  const allowed = new Set(DISCIPLINES_BY_MODE[mode] || []);
-  const matchesFilter = (disc, sub) => {
-    if(!allowed.has(disc)) return false;
-    if(normalizedFilter?.disc && disc !== normalizedFilter.disc) return false;
-    if(normalizedFilter?.sub && normalizedFilter.sub !== ALL_SUB && sub !== normalizedFilter.sub) return false;
-    return true;
-  };
+  const modes = mode === REVIEW_ALL_MODE ? Object.keys(DISCIPLINES_BY_MODE) : [mode];
   const combined = [];
-  const pushQuestionsFromExam = exam => {
-    const questions = areaData[exam] || [];
-    questions.forEach(({disc,sub,q})=>{
-      if(!matchesFilter(disc,sub)) return;
-      const key = qKey(disc,sub,q.label);
-      const state = getStoredQuestionState(disc, sub, q.label);
-      const effectiveState = getEffectiveStateFromKey(key, state);
-      const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
-      const isFavorite = localStorage.getItem(favoriteKey) === '1';
-      if(effectiveState === 2){
-        combined.push({exam,mode,disc,sub,q,type:'wrong',favorite:isFavorite});
-      }
+  modes.forEach(currentMode => {
+    const areaData = examsDataByMode[currentMode] || {};
+    const examOrder = examOrderByMode[currentMode] || [];
+    const visited = new Set();
+    const allowed = new Set(DISCIPLINES_BY_MODE[currentMode] || []);
+    const matchesFilter = (disc, sub) => {
+      if(!allowed.has(disc)) return false;
+      if(normalizedFilter?.disc && disc !== normalizedFilter.disc) return false;
+      if(normalizedFilter?.sub && normalizedFilter.sub !== ALL_SUB && sub !== normalizedFilter.sub) return false;
+      return true;
+    };
+    const pushQuestionsFromExam = exam => {
+      const questions = areaData[exam] || [];
+      questions.forEach(({disc,sub,q})=>{
+        if(!matchesFilter(disc,sub)) return;
+        const key = qKey(disc,sub,q.label);
+        const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
+        const isFavorite = localStorage.getItem(favoriteKey) === '1';
+        const effectiveState = getEffectiveQuestionState(disc, sub, q.label);
+        if(kind === 'favorite'){
+          if(isFavorite) combined.push({exam,mode:currentMode,disc,sub,q,type:'favorite',favorite:isFavorite});
+        }else if(effectiveState === 2){
+          combined.push({exam,mode:currentMode,disc,sub,q,type:'wrong',favorite:isFavorite});
+        }
+      });
+      visited.add(exam);
+    };
+    examOrder.forEach(exam => pushQuestionsFromExam(exam));
+    Object.keys(areaData).forEach(exam => {
+      if(!visited.has(exam)) pushQuestionsFromExam(exam);
     });
-    visited.add(exam);
-  };
-  examOrder.forEach(exam => pushQuestionsFromExam(exam));
-  Object.keys(areaData).forEach(exam => {
-    if(!visited.has(exam)) pushQuestionsFromExam(exam);
   });
   return combined;
 }
 
 function computeNatReviewSnapshot(items){
   if (typeof localStorage === 'undefined') {
-    return { wrongCount: 0, totalCount: 0, reviewedCount: 0 };
+    return { totalCount: 0, reviewedCount: 0 };
   }
-  let wrongCount = 0;
   let reviewedCount = 0;
   items.forEach(item=>{
     const key = qKey(item.disc,item.sub,item.q.label);
-    const effectiveState = getEffectiveQuestionState(item.disc, item.sub, item.q.label);
-    if(effectiveState !== 2) return;
-    wrongCount += 1;
     const reviewKey = `natReview_${key}`;
     const reviewState = +localStorage.getItem(reviewKey) || 0;
     if(reviewState > 0){
       reviewedCount += 1;
     }
   });
-  return { wrongCount, totalCount: wrongCount, reviewedCount };
+  return { totalCount: items.length, reviewedCount };
 }
 
 function countNatReviewItems(filter=null){
@@ -3059,6 +3171,7 @@ function showExam(exam){
       }
     });
     row.appendChild(qBtn);
+    attachFavoriteQuestionMenu(row, qBtn, disc, sub, q.label);
     row.appendChild(Object.assign(document.createElement('button'),{
       textContent:'Gabarito',
       className:'small-btn',
@@ -3119,11 +3232,11 @@ function showNatReview(filter=null){
   if(filter){
     setNatReviewState(filter);
   }
-  const { mode: reviewMode = 'nat', disc, sub } = natReviewState;
+  const { mode: reviewMode = REVIEW_ALL_MODE, disc, sub, kind: reviewKind = 'wrong' } = natReviewState;
   const isAll = disc === REVIEW_ALL_DISC;
   const effectiveFilter = isAll
-    ? { mode: reviewMode }
-    : { mode: reviewMode, disc, sub };
+    ? { mode: reviewMode, kind: reviewKind }
+    : { mode: reviewMode, disc, sub, kind: reviewKind };
   currentDisc = null;
   currentSub = null;
   currentExam = null;
@@ -3135,15 +3248,16 @@ function showNatReview(filter=null){
   toggleSettingsVisibility(false);
   toggleReviewSettingsVisibility(true);
   renderReviewSettingsMenu();
-  const areaLabel = REVIEW_MODE_LABELS[reviewMode] || 'Revisão';
-  let headerLabel = `Revisão: ${areaLabel}`;
+  const areaLabel = REVIEW_MODE_LABELS[reviewMode] || 'Todas';
+  const reviewTitle = reviewKind === 'favorite' ? 'Revisão (Favoritas)' : 'Revisão (Erradas)';
+  let headerLabel = `${reviewTitle}: ${areaLabel}`;
   if(!isAll){
-    headerLabel = `Revisão: ${disc}`;
+    headerLabel = `${reviewTitle}: ${disc}`;
     if(sub && sub !== ALL_SUB){
       headerLabel += `: ${getFriendlyName(disc, sub)}`;
     }
   }else{
-    headerLabel = `Revisão: ${areaLabel}`;
+    headerLabel = `${reviewTitle}: ${areaLabel}`;
   }
   updateHeader(true, headerLabel);
   summaryBtn.style.display = 'none';
@@ -3161,7 +3275,7 @@ function showNatReview(filter=null){
   const itemsForView = collectNatReviewItems(effectiveFilter);
   const baseEmptyText = (!isAll || (sub && sub !== ALL_SUB))
     ? 'Nenhuma questão para revisar no filtro escolhido.'
-    : 'Nenhuma questão errada ou pendente encontrada nos simulados.';
+    : (reviewKind === 'favorite' ? 'Nenhuma questão favorita encontrada.' : 'Nenhuma questão errada encontrada nos simulados.');
 
   const emptyMsg = document.createElement('p');
   emptyMsg.className = 'review-empty';
@@ -3178,8 +3292,8 @@ function showNatReview(filter=null){
 
   const refreshStats = () => {
     const snapshot = computeNatReviewSnapshot(itemsForView);
-    const { wrongCount, reviewedCount, totalCount } = snapshot;
-    const text = `Erradas (todos os simulados): ${wrongCount} | Revisadas: ${reviewedCount}/${totalCount}`;
+    const { reviewedCount, totalCount } = snapshot;
+    const text = `Revisadas: ${reviewedCount}/${totalCount}`;
     stats.textContent = text;
     stats.className = 'stat';
   };
@@ -3188,14 +3302,16 @@ function showNatReview(filter=null){
 
   itemsForView.forEach(item => {
     const key = qKey(item.disc, item.sub, item.q.label);
+    const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
     let st = getStoredQuestionState(item.disc, item.sub, item.q.label);
     const qualifies = () => {
+      if (reviewKind === 'favorite') {
+        return localStorage.getItem(favoriteKey) === '1';
+      }
       const effective = getEffectiveStateFromKey(key, st);
       return effective === 2;
     };
     if (!qualifies()) return;
-
-    const favoriteKey = `${NAT_REVIEW_FAVORITE_PREFIX}${key}`;
 
     let isFavorite = !!item.favorite;
 
@@ -3391,6 +3507,9 @@ function showNatReview(filter=null){
       }
       paintFavorite();
       syncWithReviewState();
+      if (reviewKind === 'favorite' && !isFavorite) {
+        row.remove();
+      }
       ensureEmptyState();
       refreshStats();
       closeMenu();
@@ -3636,6 +3755,7 @@ function showQuestions(disc, sub, fromStar = false, fromTrailSub = false) {
 
     qBtn.onclick = () => openPdf(q.QPDFName, q.page);
     row.appendChild(qBtn);
+    attachFavoriteQuestionMenu(row, qBtn, disc, sub, q.label);
 
     /* Botão gabarito */
     row.appendChild(Object.assign(
@@ -5410,6 +5530,7 @@ function showMicroSim(entry) {
     }
     qBtn.onclick = () => openPdf(q.QPDFName, q.page);
     row.appendChild(qBtn);
+    attachFavoriteQuestionMenu(row, qBtn, disc, sub, q.label);
 
     row.appendChild(Object.assign(
       document.createElement('button'),{

--- a/main.js
+++ b/main.js
@@ -2570,61 +2570,14 @@ function openPicker(callback){
       pickerMicro.style.display='none';
       pickerExamMode.style.display='';
       pickerExam.style.display='none';
+      pickerReviewDisc.style.display='none';
+      pickerSub.style.display='none';
+      pickerReviewDisc.innerHTML='';
+      pickerSub.innerHTML='';
       pickerExamMode.innerHTML =
         '<option value="wrong">Erradas</option>'+
         '<option value="favorite">Favoritas</option>';
-      pickerReviewDisc.style.display='';
-      pickerSub.style.display='';
-      pickerReviewDisc.innerHTML='';
-      const reviewMode = normalizeReviewModes(natReviewState.modes)[0] || 'nat';
-      const reviewAreaLabel = REVIEW_MODE_LABELS[reviewMode] || 'Área';
-      const optAllDisc=document.createElement('option');
-      optAllDisc.value=REVIEW_ALL_DISC;
-      optAllDisc.textContent=`Revisão: ${reviewAreaLabel}`;
-      pickerReviewDisc.appendChild(optAllDisc);
-      getReviewDisciplineOptions(reviewMode).forEach(disc=>{
-        const opt=document.createElement('option');
-        opt.value=disc;
-        opt.textContent=disc;
-        pickerReviewDisc.appendChild(opt);
-      });
-      if(!pickerReviewDisc.options.length){
-        pickerSub.innerHTML='';
-        pickerAdd.disabled = true;
-        return;
-      }
       pickerAdd.disabled = false;
-      const populateReviewSubs = ()=>{
-        const disc = pickerReviewDisc.value;
-        pickerSub.innerHTML='';
-        if(!disc){
-          pickerAdd.disabled = true;
-          return;
-        }
-        pickerAdd.disabled = false;
-        const isAll = disc === REVIEW_ALL_DISC;
-        pickerSub.style.display = isAll ? 'none' : '';
-        if(isAll){
-          const opt=document.createElement('option');
-          opt.value=ALL_SUB;
-          opt.textContent=`Revisão: ${reviewAreaLabel}`;
-          pickerSub.appendChild(opt);
-          pickerSub.value=ALL_SUB;
-          return;
-        }
-        const optAll=document.createElement('option');
-        optAll.value=ALL_SUB;
-        optAll.textContent='Disciplina Inteira';
-        pickerSub.appendChild(optAll);
-        (SUBJECT_NAMES[disc]||[]).forEach((n,i)=>{
-          const o=document.createElement('option');
-          o.value=String(i+1).padStart(2,'0');
-          o.textContent=n;
-          pickerSub.appendChild(o);
-        });
-      };
-      pickerReviewDisc.onchange = populateReviewSubs;
-      populateReviewSubs();
     }else{
       hideReviewSelectors();
       pickerSub.style.display='';
@@ -2655,12 +2608,7 @@ function openPicker(callback){
     }else if(pickerDisc.value==='__exams__'){
       callback({exam:pickerExam.value,mode:pickerExamMode.value});
     }else if(pickerDisc.value==='__review__'){
-      const reviewDisc = pickerReviewDisc.value;
-      if(!reviewDisc){
-        alert('Selecione uma disciplina para revisar.');
-        return;
-      }
-      callback({review:true, kind: pickerExamMode.value === 'favorite' ? 'favorite' : 'wrong', mode: reviewMode, disc: reviewDisc, sub: pickerSub.value});
+      callback({review:true, kind: pickerExamMode.value === 'favorite' ? 'favorite' : 'wrong'});
     }else{
       callback({disc: pickerDisc.value, sub: pickerSub.value});
     }
@@ -2805,32 +2753,22 @@ function renderTrailDay(day,expand){
       if(s.review){
         const subj=document.createElement('button');
         subj.className='trail-subject trail-review';
-        const isAllDisc = s.disc === REVIEW_ALL_DISC;
-        const hasAll = isAllDisc || s.sub === ALL_SUB;
         const reviewKind = s.kind === 'favorite' ? 'favorite' : 'wrong';
-        const labelParts = [reviewKind === 'favorite' ? 'Revisão (Favoritas)' : 'Revisão (Erradas)'];
-        const mode = s.mode || normalizeReviewModes(natReviewState.modes)[0] || 'nat';
-        const areaLabel = REVIEW_MODE_LABELS[mode] || 'Área';
-        if(isAllDisc){
-          labelParts.push(areaLabel);
-        }else{
-          labelParts.push(s.disc);
-          if(!hasAll){
-            labelParts.push(getFriendlyName(s.disc,s.sub));
-          }
-        }
-        subj.textContent=labelParts.join(': ');
+        subj.textContent = reviewKind === 'favorite' ? 'Revisão (Favoritas)' : 'Revisão (Erradas)';
         subj.onclick=()=>{
           trailReturn=dayStr;
           trailReturnSub=false;
-          const filter = isAllDisc
-            ? {mode, kind: reviewKind, disc:REVIEW_ALL_DISC}
-            : {mode, kind: reviewKind, disc:s.disc, sub:s.sub};
-          showNatReview(filter);
+          resetNatReviewState(reviewKind);
+          showNatReview();
         };
         const count=document.createElement('span');
         count.className='trail-count';
-        const countFilter = isAllDisc ? { mode, kind: reviewKind } : { mode, kind: reviewKind, disc:s.disc, sub:s.sub };
+        const defaultModes = REVIEW_DEFAULT_MODES.slice();
+        const countFilter = {
+          kind: reviewKind,
+          modes: defaultModes,
+          discs: getReviewDisciplinesForModes(defaultModes)
+        };
         count.textContent=countNatReviewItems(countFilter).toString();
         const rm=document.createElement('button');
         rm.className='trail-remove';

--- a/main.js
+++ b/main.js
@@ -337,6 +337,9 @@ const natReviewBtn  = document.getElementById("natReviewBtn");
 const reviewModeBtn = document.getElementById("reviewModeBtn");
 const clearManuscriptsBtn = document.getElementById("clearManuscriptsBtn");
 const clearCacheBtn = document.getElementById("clearCacheBtn");
+const programmerBtn = document.getElementById("programmerBtn");
+const programmerMenu = document.getElementById("programmerMenu");
+const clearQuestionsBtn = document.getElementById("clearQuestionsBtn");
 const pickerModal   = document.getElementById("subjectPickerModal");
 const pickerDisc    = document.getElementById("pickerDisc");
 const pickerReviewDisc = document.getElementById("pickerReviewDisc");
@@ -1120,6 +1123,20 @@ function removeHandwritingEntriesFromLocalStorage() {
   });
 }
 
+
+function clearQuestionDataFromLocalStorage() {
+  if (typeof localStorage === 'undefined') return 0;
+  const keysToRemove = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+    if (!isHandwritingStorageKey(key)) {
+      keysToRemove.push(key);
+    }
+  }
+  keysToRemove.forEach((key) => localStorage.removeItem(key));
+  return keysToRemove.length;
+}
+
 function getExportFilenamePrefix(mode) {
   return mode === 'handwriting' ? 'Newtonius_handwriting' : 'Newtonius';
 }
@@ -1415,7 +1432,7 @@ function getEffectiveQuestionState(disc, sub, label) {
 
 function updateReviewModeButton() {
   if (!reviewModeBtn) return;
-  reviewModeBtn.textContent = postReviewMode ? 'Pré-Revisão' : 'Pós-Revisão';
+  reviewModeBtn.textContent = postReviewMode ? 'Estatísticas Pré-Revisão' : 'Estatísticas Pós-Revisão';
 }
 
 function refreshReviewModeUI() {
@@ -2033,6 +2050,30 @@ if (importHandBtn) {
     importFile.value = '';
     importFile.dataset.mode = 'handwriting';
     importFile.click();
+  };
+}
+
+
+if (programmerBtn && programmerMenu) {
+  programmerBtn.onclick = (event) => {
+    event.stopPropagation();
+    const expanded = programmerMenu.style.display === 'flex';
+    programmerMenu.style.display = expanded ? 'none' : 'flex';
+    programmerBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+  };
+}
+
+if (clearQuestionsBtn) {
+  clearQuestionsBtn.onclick = () => {
+    settingsMenu.style.display = 'none';
+    const confirmed = confirm(
+      'Deseja apagar todos os dados de questões, comentários e revisão? Manuscritos e cache não serão apagados por esta ação.'
+    );
+    if (!confirmed) return;
+
+    const removedCount = clearQuestionDataFromLocalStorage();
+    alert(`${removedCount} dado(s) de questões foram apagados.`);
+    window.location.reload();
   };
 }
 

--- a/styles.css
+++ b/styles.css
@@ -223,7 +223,7 @@ button:hover { filter: brightness(1.2); }
 .disc-btn {
   position: relative;
   width: 200px;
-  height: 33px;
+  height: 40px;
   font-size: 16px;
   color: #fff;
   font-weight: bold;

--- a/styles.css
+++ b/styles.css
@@ -1254,6 +1254,8 @@ button:hover { filter: brightness(1.2); }
 .trail-subject.sem-assunto-hum      { background: var(--c-sem-assunto); color: var(--c-bg-app); }
 .trail-subject.sem-assunto-mat      { background: var(--c-sem-assunto); color: var(--c-bg-app); }
 .trail-subject.trail-review         { background: #9fe3b1; color: #0a3a1f; }
+.trail-subject.trail-review-wrong   { background: #ff6b6b; color: #2b0000; }
+.trail-subject.trail-review-favorite{ background: #ffd36b; color: #3b2500; }
 /* Exams */
 .trail-subject.exam-enem      { background: var(--c-exam-enem); }
 .trail-subject.exam-sas       { background: var(--c-exam-sas); }

--- a/styles.css
+++ b/styles.css
@@ -221,6 +221,7 @@ button:hover { filter: brightness(1.2); }
 
 /* --- Botão da disciplina (com cor própria) --- */
 .disc-btn {
+  position: relative;
   width: 200px;
   height: 33px;
   font-size: 16px;
@@ -230,6 +231,19 @@ button:hover { filter: brightness(1.2); }
   align-items: center;         /* centra o conteúdo na altura          */
   justify-content: center;     /* já centraliza horizontalmente também */
   white-space: nowrap;
+}
+.disc-btn-label{
+  display:block;
+}
+.disc-btn-stats{
+  position:absolute;
+  right:6px;
+  bottom:3px;
+  font-size:8px;
+  line-height:1;
+  font-weight:700;
+  opacity:.82;
+  pointer-events:none;
 }
 .disc-btn.biologia             { background: var(--c-bio); }
 .disc-btn.quimica              { background: var(--c-qui); }

--- a/styles.css
+++ b/styles.css
@@ -343,7 +343,7 @@ button:hover { filter: brightness(1.2); }
   opacity: 0.6;
 }
 
-.question-row.review-favorite .question-btn {
+.question-row.review-favorite .btn {
   box-shadow: 0 0 0 2px rgba(255, 211, 107, 0.35);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -239,10 +239,11 @@ button:hover { filter: brightness(1.2); }
   position:absolute;
   right:6px;
   bottom:3px;
-  font-size:8px;
+  color:#000;
+  font-size:10px;
   line-height:1;
-  font-weight:700;
-  opacity:.82;
+  font-weight:800;
+  opacity:.9;
   pointer-events:none;
 }
 .disc-btn.biologia             { background: var(--c-bio); }

--- a/styles.css
+++ b/styles.css
@@ -1032,6 +1032,23 @@ button:hover { filter: brightness(1.2); }
   opacity:.45;
   cursor:default;
 }
+#settingsMenu .settings-hidden-control{
+  display:none;
+}
+.settings-programmer-group{
+  display:flex;
+  flex-direction:column;
+}
+#settingsMenu .settings-submenu{
+  display:none;
+  flex-direction:column;
+  margin-top:4px;
+  padding-left:10px;
+  border-left:1px solid var(--c-border-muted);
+}
+#settingsMenu .settings-submenu button{
+  font-size:13px;
+}
 /* === Trilha Estratégica (v2) === */
 .day-btn {
   width: 100%;


### PR DESCRIPTION
### Motivation
- Tornar mais claro o propósito dos controles de revisão e estatísticas ao renomear os rótulos relacionados à revisão.
- Ocultar alguns controles (D1 e Handwriting import/export) da interface sem removê-los do código para mantê-los acessíveis futuramente.
- Fornecer ferramentas de manutenção agrupadas sob um botão "Programador" para limpar dados de questões, manuscritos e cache em um único lugar.

### Description
- Atualizei `index.html` para renomear `Revisão` para `Revisão (Erradas)` e mudar o rótulo inicial do botão de modo para `Estatísticas Pós-Revisão`, além de adicionar o grupo `Programador` com o submenu que inclui `Limpar Questões`, `Limpar Manuscritos` e `Limpar Cache`.
- Modifiquei `main.js` para expor novos elementos (`programmerBtn`, `programmerMenu`, `clearQuestionsBtn`), para atualizar o texto de `reviewModeBtn` (`Estatísticas Pré-Revisão` / `Estatísticas Pós-Revisão`) e para implementar a função `clearQuestionDataFromLocalStorage()` que remove todas as chaves de `localStorage` que não sejam manuscritos (handwriting), além dos handlers do submenu que exibem confirmações e recarregam a página.
- Ocultei visualmente os botões `toggleD1Btn`, `importHandBtn` e `exportHandBtn` adicionando a classe `settings-hidden-control` em `index.html` e regras CSS em `styles.css`, mantendo os elementos e seus handlers intactos.
- Adicionei estilos em `styles.css` para suportar a nova estrutura do submenu do Programador (`.settings-programmer-group` e `.settings-submenu`).

### Testing
- Executado `node --check main.js` para checar a sintaxe do JavaScript e o comando concluiu sem erros.
- Executado `git diff --check` para validar o diff e não foram encontrados problemas de espaço em branco ou similar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4582cda438832186691d99a051d670)