### PR TITLE
Include PDF manuscritos in general backup and disable local image insert in editor

### DIFF
--- a/Editor_de_Texto.html
+++ b/Editor_de_Texto.html
@@ -210,7 +210,7 @@ button:hover{background:var(--accent);}button:active{transform:scale(.96);}#mess
 
   <button id="hideBtn">🤫 Ocultar Texto</button>
   <button id="clearBtn">🧹 Limpar Formatação</button>
-  <button id="insertImgBtn">📷 Inserir Imagem</button>
+  <button id="insertImgBtn" disabled aria-disabled="true" title="Inserção de imagens locais desabilitada. Use links de imagem (ex.: Firebase) no texto.">📷 Inserir Imagem</button>
   <input type="file" id="fileInput" accept="image/*" hidden />
 
   <button id="insertBtn">◼️ Ocultar Imagem (Tarja)</button>
@@ -552,16 +552,14 @@ clearBtn.onclick = () => {
 
 
 /* ---------- INSERIR IMAGEM ---------- */
-insertImgBtn.onclick = ()=>{saveSel();fileInput.click();};
+insertImgBtn.onclick = (e)=>{e.preventDefault();};
 fileInput.onchange=e=>{
-  const f=e.target.files[0];if(!f)return;
-  const r=new FileReader();r.onload=ev=>{insertImg(ev.target.result);fileInput.value='';};r.readAsDataURL(f);
+  fileInput.value='';
 };
 editor.addEventListener('paste',e=>{
   for(const it of e.clipboardData.items){
     if(it.type.startsWith('image/')){
-      const f=it.getAsFile();const r=new FileReader();
-      r.onload=ev=>insertImg(ev.target.result);r.readAsDataURL(f);e.preventDefault();
+      e.preventDefault();
     }
   }
   setTimeout(()=>replaceArrows(editor,true),0);
@@ -569,7 +567,7 @@ editor.addEventListener('paste',e=>{
 editor.addEventListener('drop',e=>{
   for(const f of e.dataTransfer.files){
     if(f.type.startsWith('image/')){
-      const r=new FileReader();r.onload=ev=>insertImg(ev.target.result);r.readAsDataURL(f);e.preventDefault();
+      e.preventDefault();
     }
   }
 });

--- a/main.js
+++ b/main.js
@@ -1115,7 +1115,7 @@ function isHandwritingStorageKey(key) {
 function shouldIncludeKeyForExport(key, mode) {
   const handwriting = isHandwritingStorageKey(key);
   if (mode === 'handwriting') return handwriting;
-  return !handwriting;
+  return true;
 }
 
 function shouldIncludeKeyForImport(key, mode) {


### PR DESCRIPTION
### Motivation
- Ensure that general backup/import operations also include PDF handwriting/manuscrito data so users keep their handwritten annotations when exporting or importing a full backup.
- Keep the editor's `Inserir Imagem` control visible but prevent local image insertion while preserving image-by-URL behavior (e.g., Firebase links). 

### Description
- Changed `shouldIncludeKeyForExport` (and import via shared logic) to include handwriting keys for the general mode by returning `true` for non-`handwriting` modes so PDF draw keys (`pdfDraw::...`) are exported/imported in general backups (`main.js`).
- Kept the `handwriting` mode behavior (`if (mode === 'handwriting') return handwriting`) so the dedicated handwriting export/import still works as intended (`main.js`).
- Disabled the editor `Inserir Imagem` button and added an explanatory `title` and `aria-disabled` attribute while preventing image insertion via the button, file input, paste and drag-and-drop handlers (`Editor_de_Texto.html`).
- Preserved existing conversion of image URLs in text to images (including Firebase links), so image insertion by text/link remains functional (`Editor_de_Texto.html`).

### Testing
- Ran `node --check main.js` which completed successfully.
- Ran `git diff --check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45bf3bc78883218799509aa72f5b3e)