### PR TITLE
Ordena simulados por recência (ano/edição)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1077,10 +1077,42 @@ function reorderExamsByFamily(order){
   familyOrder.forEach(family => {
     const exams = groups.get(family);
     if(Array.isArray(exams)){
-      exams.forEach(exam => normalized.push(exam));
+      exams
+        .slice()
+        .sort(compareExamRecency)
+        .forEach(exam => normalized.push(exam));
     }
   });
   return normalized;
+}
+
+function parseExamOrderParts(exam){
+  if(typeof exam !== 'string') return null;
+  const match = exam.match(/^(.*?)[-\s](\d{4})(?:[-\s]([A-Za-z]+|\d+))?/);
+  if(!match) return null;
+  const year = Number(match[2]);
+  if(!Number.isFinite(year)) return null;
+  const editionRaw = match[3] || '';
+  const editionNumber = /^\d+$/.test(editionRaw) ? Number(editionRaw) : null;
+  return {
+    year,
+    editionNumber: Number.isFinite(editionNumber) ? editionNumber : -1,
+    editionText: editionRaw.toUpperCase()
+  };
+}
+
+function compareExamRecency(a, b){
+  const pa = parseExamOrderParts(a);
+  const pb = parseExamOrderParts(b);
+  if(pa && pb){
+    if(pa.year !== pb.year) return pb.year - pa.year;
+    if(pa.editionNumber !== pb.editionNumber) return pb.editionNumber - pa.editionNumber;
+    const textCmp = pb.editionText.localeCompare(pa.editionText, 'pt-BR', { numeric: true });
+    if(textCmp !== 0) return textCmp;
+  }else if(pa || pb){
+    return pa ? -1 : 1;
+  }
+  return String(a).localeCompare(String(b), 'pt-BR', { numeric: true });
 }
 
 function getExamFamily(exam){

--- a/main.js
+++ b/main.js
@@ -1079,7 +1079,7 @@ function reorderExamsByFamily(order){
     if(Array.isArray(exams)){
       exams
         .slice()
-        .sort(compareExamRecency)
+        .sort(compareExamChronology)
         .forEach(exam => normalized.push(exam));
     }
   });
@@ -1101,13 +1101,13 @@ function parseExamOrderParts(exam){
   };
 }
 
-function compareExamRecency(a, b){
+function compareExamChronology(a, b){
   const pa = parseExamOrderParts(a);
   const pb = parseExamOrderParts(b);
   if(pa && pb){
-    if(pa.year !== pb.year) return pb.year - pa.year;
-    if(pa.editionNumber !== pb.editionNumber) return pb.editionNumber - pa.editionNumber;
-    const textCmp = pb.editionText.localeCompare(pa.editionText, 'pt-BR', { numeric: true });
+    if(pa.year !== pb.year) return pa.year - pb.year;
+    if(pa.editionNumber !== pb.editionNumber) return pa.editionNumber - pb.editionNumber;
+    const textCmp = pa.editionText.localeCompare(pb.editionText, 'pt-BR', { numeric: true });
     if(textCmp !== 0) return textCmp;
   }else if(pa || pb){
     return pa ? -1 : 1;


### PR DESCRIPTION
### Motivation
- Corrigir a ordem dos simulados dentro de cada família para que exames mais recentes apareçam antes dos antigos (ex.: `SAS-2026-1` deve vir antes de `SAS-2025-6`).

### Description
- Modifica `reorderExamsByFamily` em `main.js` para ordenar cada família usando uma função de comparação que prioriza ano e edição. 
- Adiciona `parseExamOrderParts` para extrair `year`, `editionNumber` e `editionText` do rótulo do exame. 
- Adiciona `compareExamRecency` que compara por `year` decrescente, depois por `editionNumber` decrescente e por texto em `pt-BR` quando necessário. 
- Mantém fallback para comparação alfanumérica quando não for possível extrair componentes de data/edição.

### Testing
- Executado `node --check main.js` e passou sem erros. 
- Executado snippet Node que ordena `['SAS-2025-6','SAS-2026-1','SAS-2025-5']` e validou que o resultado é `SAS-2026-1,SAS-2025-6,SAS-2025-5` (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45d6f54b5883218c4d4622f54ae528)